### PR TITLE
Generate friendly `Address` from String

### DIFF
--- a/crates/svm-common/src/address.rs
+++ b/crates/svm-common/src/address.rs
@@ -160,11 +160,11 @@ mod tests {
     #[test]
     fn address_from_str() {
         let bytes: [u8; 20] = [
-            b'@', b'a', b'd', b'd', b'r', b'e', b's', b's', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            b'a', b'd', b'd', b'r', b'e', b's', b's', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         ];
 
         let expected = Address::from(&bytes[..]);
-        let actual = Address::from("@address");
+        let actual = Address::of("address");
 
         assert_eq!(expected, actual);
     }

--- a/crates/svm-common/src/address.rs
+++ b/crates/svm-common/src/address.rs
@@ -158,6 +158,18 @@ mod tests {
     }
 
     #[test]
+    fn address_from_str() {
+        let bytes: [u8; 20] = [
+            b'@', b'a', b'd', b'd', b'r', b'e', b's', b's', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        ];
+
+        let expected = Address::from(&bytes[..]);
+        let actual = Address::from("@address");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
     fn address_from_u32() {
         let expected = Address([
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,

--- a/crates/svm-common/src/helpers.rs
+++ b/crates/svm-common/src/helpers.rs
@@ -9,6 +9,21 @@ pub fn u32_to_be_array(num: u32) -> [u8; 4] {
     [b3, b2, b1, b0]
 }
 
+/// Converts an unsigned 64-bit integer into a 8-byte array (ordered in Big-Endian)
+#[inline(always)]
+pub fn u64_to_be_array(num: u64) -> [u8; 8] {
+    let b7 = ((num >> 56) & 0xFF) as u8;
+    let b6 = ((num >> 48) & 0xFF) as u8;
+    let b5 = ((num >> 40) & 0xFF) as u8;
+    let b4 = ((num >> 32) & 0xFF) as u8;
+    let b3 = ((num >> 24) & 0xFF) as u8;
+    let b2 = ((num >> 16) & 0xFF) as u8;
+    let b1 = ((num >> 8) & 0xFF) as u8;
+    let b0 = (num & 0xFF) as u8;
+
+    [b7, b6, b5, b4, b3, b2, b1, b0]
+}
+
 /// Converts an unsigned 32-bit integer into a 4-byte array (ordered in Little-Endian)
 #[inline(always)]
 pub fn u32_to_le_array(num: u32) -> [u8; 4] {
@@ -32,21 +47,6 @@ pub fn u64_to_le_array(num: u64) -> [u8; 8] {
     let b5 = ((num >> 16) & 0xFF) as u8;
     let b6 = ((num >> 8) & 0xFF) as u8;
     let b7 = (num & 0xFF) as u8;
-
-    [b7, b6, b5, b4, b3, b2, b1, b0]
-}
-
-/// Converts an unsigned 64-bit integer into a 8-byte array (ordered in Big-Endian)
-#[inline(always)]
-pub fn u64_to_be_array(num: u64) -> [u8; 8] {
-    let b7 = ((num >> 56) & 0xFF) as u8;
-    let b6 = ((num >> 48) & 0xFF) as u8;
-    let b5 = ((num >> 40) & 0xFF) as u8;
-    let b4 = ((num >> 32) & 0xFF) as u8;
-    let b3 = ((num >> 24) & 0xFF) as u8;
-    let b2 = ((num >> 16) & 0xFF) as u8;
-    let b1 = ((num >> 8) & 0xFF) as u8;
-    let b0 = (num & 0xFF) as u8;
 
     [b7, b6, b5, b4, b3, b2, b1, b0]
 }
@@ -87,25 +87,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_u32_to_be_array() {
-        let expected = [0x11, 0x22, 0x33, 0x44];
-        let actual = u32_to_be_array(0x11_22_33_44);
-
-        assert_eq!(expected, actual);
-    }
-
-    #[test]
     fn test_u32_to_le_array() {
         let expected = [0x44, 0x33, 0x22, 0x11];
         let actual = u32_to_le_array(0x11_22_33_44);
-
-        assert_eq!(expected, actual);
-    }
-
-    #[test]
-    fn test_u64_to_be_array() {
-        let expected = [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88];
-        let actual = u64_to_be_array(0x11_22_33_44_55_66_77_88);
 
         assert_eq!(expected, actual);
     }

--- a/crates/svm-common/src/macros.rs
+++ b/crates/svm-common/src/macros.rs
@@ -102,11 +102,9 @@ macro_rules! impl_bytes_primitive {
                     crate::fmt::fmt_hex(last.as_slice(), separator)
                 )
             }
-        }
 
-        /// Should be used **only** for tests
-        impl From<&str> for $primitive {
-            fn from(s: &str) -> $primitive {
+            /// Should be used **only** for tests
+            pub fn of(s: &str) -> $primitive {
                 let mut buf = [0; $byte_count];
 
                 let bytes = s.as_bytes();
@@ -120,6 +118,7 @@ macro_rules! impl_bytes_primitive {
                 $primitive(buf)
             }
         }
+
         /// Should be used **only** for tests
         #[doc(hidden)]
         impl From<u32> for $primitive {

--- a/crates/svm-common/src/macros.rs
+++ b/crates/svm-common/src/macros.rs
@@ -105,6 +105,22 @@ macro_rules! impl_bytes_primitive {
         }
 
         /// Should be used **only** for tests
+        impl From<&str> for $primitive {
+            fn from(s: &str) -> $primitive {
+                let mut buf = [0; $byte_count];
+
+                let bytes = s.as_bytes();
+
+                assert!(bytes.len() <= $byte_count);
+
+                unsafe {
+                    std::ptr::copy(bytes.as_ptr(), buf.as_mut_ptr(), bytes.len());
+                }
+
+                $primitive(buf)
+            }
+        }
+        /// Should be used **only** for tests
         #[doc(hidden)]
         impl From<u32> for $primitive {
             fn from(n: u32) -> $primitive {

--- a/crates/svm-kv/tests/memory_kv_tests.rs
+++ b/crates/svm-kv/tests/memory_kv_tests.rs
@@ -12,7 +12,7 @@ fn a_key_does_not_exit_by_default() {
     init();
 
     let kv = MemKVStore::new();
-    let addr = Address::from(0x11_22_33_44 as u32);
+    let addr = Address::of("@someone");
 
     assert_no_key!(kv, addr.as_slice());
 }
@@ -22,7 +22,7 @@ fn key_store_and_then_key_get() {
     init();
 
     let mut kv = MemKVStore::new();
-    let addr = Address::from(0x11_22_33_44 as u32);
+    let addr = Address::of("someone");
     kv.store(&[(addr.as_slice(), &[10, 20, 30])]);
 
     assert_key_value!(kv, addr.as_slice(), vec![10, 20, 30]);
@@ -33,7 +33,7 @@ fn key_store_override_existing_entry() {
     init();
 
     let mut kv = MemKVStore::new();
-    let addr = Address::from(0x11_22_33_44 as u32);
+    let addr = Address::of("someone");
 
     kv.store(&[(addr.as_slice(), &[10, 20, 30])]);
     assert_key_value!(kv, addr.as_slice(), vec![10, 20, 30]);
@@ -47,8 +47,8 @@ fn clear() {
     init();
 
     let mut kv = MemKVStore::new();
-    let addr1 = Address::from(0x11_22_33_44 as u32);
-    let addr2 = Address::from(0x55_66_77_88 as u32);
+    let addr1 = Address::of("Alice");
+    let addr2 = Address::of("Bob");
 
     kv.store(&[
         (addr1.as_slice(), &[10, 20, 30]),

--- a/crates/svm-runtime-c-api/src/receipt.rs
+++ b/crates/svm-runtime-c-api/src/receipt.rs
@@ -150,7 +150,7 @@ mod tests {
     #[test]
     fn encode_receipt_error() {
         let error = ExecAppError::AppNotFound {
-            app_addr: Address::from(0x10_20_30_40),
+            app_addr: Address::of("my-app"),
         };
 
         let expected = ClientReceipt::Failure {

--- a/crates/svm-runtime-c-api/tests/api_tests.rs
+++ b/crates/svm-runtime-c-api/tests/api_tests.rs
@@ -137,7 +137,7 @@ fn host_ctx_bytes(version: u32, fields: HashMap<i32, Vec<u8>>) -> (Vec<u8>, u32)
 }
 
 fn exec_app_args() -> (Address, i64, Vec<Vec<u8>>, Vec<WasmValue>, State) {
-    let sender = Address::from(0x50_60_70_80);
+    let sender = Address::of("sender");
     let mul_by = 3;
     let func_buf = vec![];
     let func_args = vec![WasmValue::I64(mul_by)];
@@ -174,7 +174,7 @@ unsafe fn do_ffi_exec_app() {
     assert_eq!(true, res.as_bool());
 
     // 2) deploy app-template
-    let author = Address::from(0x10_20_30_40);
+    let author = Address::of("author");
     let code = include_str!("wasm/update-balance.wast");
     let pages_count = 10;
     let (hctx_bytes, hctx_len) = host_ctx_bytes(version, hashmap! {});
@@ -194,7 +194,7 @@ unsafe fn do_ffi_exec_app() {
 
     // 3) spawn app
     let mut app_addr = std::ptr::null_mut();
-    let creator = Address::from(0x20_30_40_50);
+    let creator = Address::of("creator");
     let ctor_buf = vec![];
     let ctor_args = vec![];
     let (hctx_bytes, hctx_len) = host_ctx_bytes(version, hashmap! {});

--- a/crates/svm-runtime/tests/runtime.rs
+++ b/crates/svm-runtime/tests/runtime.rs
@@ -12,8 +12,8 @@ fn runtime_spawn_app_with_ctor() {
     let imports = Vec::new();
     let mut runtime = testing::create_memory_runtime(host, &kv, imports);
     let pages_count = 10;
-    let author = Address::from(0x10_20_30_40);
-    let creator = Address::from(0x20_30_40_50);
+    let author = Address::of("author");
+    let creator = Address::of("creator");
 
     // 2) deploying the template
     let bytes = testing::build_template(
@@ -62,9 +62,9 @@ fn runtime_exec_app() {
     let imports = Vec::new();
     let mut runtime = testing::create_memory_runtime(host, &kv, imports);
     let pages_count = 10;
-    let author = Address::from(0x10_20_30_40);
-    let creator = Address::from(0x20_30_40_40);
-    let sender = Address::from(0x50_60_70_80);
+    let author = Address::of("author");
+    let creator = Address::of("creator");
+    let sender = Address::of("sender");
 
     // 2) deploying the template
     let bytes = testing::build_template(

--- a/crates/svm-runtime/tests/vmcalls.rs
+++ b/crates/svm-runtime/tests/vmcalls.rs
@@ -20,7 +20,7 @@ fn default_test_args() -> (
     DataWrapper<*const c_void>,
     u16,
 ) {
-    let app_addr = Address::from(0x12_34_56_78);
+    let app_addr = Address::of("my-app");
     let state = State::from(0x_00_00_00_00);
     let host = DataWrapper::new(std::ptr::null_mut());
     let host_ctx = DataWrapper::new(svm_common::into_raw(HostCtx::new()));

--- a/crates/svm-storage/src/default/page_hasher.rs
+++ b/crates/svm-storage/src/default/page_hasher.rs
@@ -50,7 +50,7 @@ mod tests {
         data.extend_from_slice(&page_data_hash);
         let expected = PageHash(DefaultKeyHasher::hash(data.as_slice()));
 
-        let addr = Address::from(0x44_33_22_11 as u32);
+        let addr = Address::from(0x44_33_22_11);
         let page_idx = PageIndex(3);
         let page_data = vec![10, 20, 30];
 

--- a/crates/svm-storage/src/default/state_hasher.rs
+++ b/crates/svm-storage/src/default/state_hasher.rs
@@ -47,7 +47,7 @@ mod tests {
         let page1: Vec<u8> = vec![10, 20, 30];
         let page2: Vec<u8> = vec![40, 50, 60];
 
-        let addr = Address::from(0xAABBCC);
+        let addr = Address::of("something");
 
         let page1_hash = DefaultPageHasher::hash(addr.clone(), PageIndex(0), &page1);
         let page2_hash = DefaultPageHasher::hash(addr.clone(), PageIndex(1), &page2);

--- a/crates/svm-storage/src/testing/app_page_cache.rs
+++ b/crates/svm-storage/src/testing/app_page_cache.rs
@@ -8,7 +8,7 @@ use crate::{default::DefaultPageCache, memory::MemAppPages, testing};
 
 /// Initialises a new page-cache backed by a new initialized in-memory pages-storage.
 pub fn app_page_cache_init(
-    addr: u32,
+    addr: &str,
     pages_count: u16,
 ) -> (
     Address,

--- a/crates/svm-storage/src/testing/app_pages.rs
+++ b/crates/svm-storage/src/testing/app_pages.rs
@@ -8,10 +8,10 @@ use crate::memory::MemAppPages;
 
 /// Initializes a new app pages backed by a new in-memory key-value store.
 pub fn app_pages_init(
-    addr: u32,
+    addr: &str,
     pages_count: u16,
 ) -> (Address, Rc<RefCell<MemKVStore>>, MemAppPages) {
-    let addr = Address::from(addr as u32);
+    let addr = Address::of(addr);
     let kv = Rc::new(RefCell::new(MemKVStore::new()));
 
     let pages = MemAppPages::new(addr.clone(), Rc::clone(&kv), State::empty(), pages_count);

--- a/crates/svm-storage/src/testing/app_storage.rs
+++ b/crates/svm-storage/src/testing/app_storage.rs
@@ -8,7 +8,7 @@ use svm_kv::memory::MemKVStore;
 
 /// Initialises a new `AppStorage` derived its address and #pages and empty state (`00...0`)
 pub fn app_storage_init(
-    addr: u32,
+    addr: &str,
     pages_count: u16,
 ) -> (Address, Rc<RefCell<MemKVStore>>, AppStorage) {
     let (addr, kv, cache) = testing::app_page_cache_init(addr, pages_count);

--- a/crates/svm-storage/src/testing/page.rs
+++ b/crates/svm-storage/src/testing/page.rs
@@ -10,8 +10,8 @@ pub fn default_page_hash(addr: &Address, page_idx: u16, data: &[u8]) -> PageHash
 }
 
 /// An helper for computing page-index hashes using `DefaultPageIndexHasher`
-pub fn default_page_index_hash(addr: u32, page_idx: u16) -> [u8; 32] {
-    let addr = Address::from(addr as u32);
+pub fn default_page_index_hash(addr: &str, page_idx: u16) -> [u8; 32] {
+    let addr = Address::of(addr);
 
     DefaultPageIndexHasher::hash(addr, PageIndex(page_idx))
 }

--- a/crates/svm-storage/tests/app_page_cache_tests.rs
+++ b/crates/svm-storage/tests/app_page_cache_tests.rs
@@ -6,7 +6,7 @@ mod asserts;
 
 #[test]
 fn page_cache_loading_an_empty_page_into_the_cache() {
-    let addr = 0x11_22_33_44;
+    let addr = "my-app";
     let pages_count = 10;
 
     let (_addr, _kv, mut cache) = app_page_cache_init(addr, pages_count);
@@ -16,7 +16,7 @@ fn page_cache_loading_an_empty_page_into_the_cache() {
 
 #[test]
 fn page_cache_write_page_and_then_commit() {
-    let addr = 0x11_22_33_44;
+    let addr = "my-app";
     let pages_count = 10;
 
     let (_addr, kv, mut cache) = app_page_cache_init(addr, pages_count);
@@ -24,13 +24,13 @@ fn page_cache_write_page_and_then_commit() {
     cache.write_page(PageIndex(0), &[10, 20, 30]);
     assert_eq!(vec![10, 20, 30], cache.read_page(PageIndex(0)).unwrap());
 
-    let ph = default_page_index_hash(0x11_22_33_44, 0);
+    let ph = default_page_index_hash("my-app", 0);
     assert_no_key!(kv, ph);
 }
 
 #[test]
 fn page_cache_writing_a_page_marks_it_as_dirty() {
-    let addr = 0x11_22_33_44;
+    let addr = "my-app";
     let pages_count = 10;
 
     let (_addr, _kv, mut cache) = app_page_cache_init(addr, pages_count);
@@ -43,7 +43,7 @@ fn page_cache_writing_a_page_marks_it_as_dirty() {
 #[test]
 #[ignore]
 fn page_cache_commit_persists_each_dirty_page() {
-    let addr = 0x11_22_33_44;
+    let addr = "my-app";
     let pages_count = 10;
 
     let (_addr, kv, mut cache) = app_page_cache_init(addr, pages_count);
@@ -51,7 +51,7 @@ fn page_cache_commit_persists_each_dirty_page() {
     cache.write_page(PageIndex(0), &[10, 20, 30]);
 
     // `cache.write_page` doesn't persist the page yet
-    let ph = default_page_index_hash(0x11_22_33_44, 0);
+    let ph = default_page_index_hash("my-app", 0);
     assert_no_key!(kv, ph);
 
     cache.commit();

--- a/crates/svm-storage/tests/app_pages_tests.rs
+++ b/crates/svm-storage/tests/app_pages_tests.rs
@@ -13,7 +13,7 @@ mod asserts;
 #[test]
 fn app_pages_first_time_run_with_no_modifications_no_commit() {
     let pages_count = 3;
-    let addr = 0x11_22_33_44;
+    let addr = "my-app";
 
     let (_addr, _kv, mut pages) = app_pages_init(addr, pages_count);
 
@@ -25,7 +25,7 @@ fn app_pages_first_time_run_with_no_modifications_no_commit() {
 #[test]
 fn app_pages_first_time_run_with_no_modifications_then_commit() {
     let pages_count = 3;
-    let addr = 0x11_22_33_44;
+    let addr = "my-app";
 
     let (addr, kv, mut pages) = app_pages_init(addr, pages_count);
     assert_eq!(0, pages.dirty_pages_count());
@@ -57,7 +57,7 @@ fn app_pages_first_time_run_with_no_modifications_then_commit() {
 #[test]
 fn app_pages_first_time_run_with_one_modified_page() {
     let pages_count = 3;
-    let addr = 0x11_22_33_44;
+    let addr = "my-app";
 
     let (addr, kv, mut pages) = app_pages_init(addr, pages_count);
 
@@ -91,7 +91,7 @@ fn app_pages_first_time_run_with_one_modified_page() {
 #[test]
 fn app_pages_first_time_run_with_two_modified_pages() {
     let pages_count = 2;
-    let addr = 0x11_22_33_44;
+    let addr = "my-app";
 
     let (addr, kv, mut pages) = app_pages_init(addr, pages_count);
 
@@ -120,7 +120,7 @@ fn app_pages_first_time_run_with_two_modified_pages() {
 fn app_pages_second_run_after_first_run_with_no_modifications() {
     // 1st run
     let pages_count = 3;
-    let addr = 0x11_22_33_44;
+    let addr = "my-app";
 
     let (addr, kv, mut pages) = app_pages_init(addr, pages_count);
     pages.commit();
@@ -157,7 +157,7 @@ fn app_pages_second_run_after_first_run_with_no_modifications() {
 fn app_pages_second_run_after_first_run_with_modifications() {
     // 1st run
     let pages_count = 3;
-    let addr = 0x11_22_33_44;
+    let addr = "my-app";
 
     let (addr, kv, mut pages) = app_pages_init(addr, pages_count);
 
@@ -202,7 +202,7 @@ fn app_pages_second_run_after_first_run_with_modifications() {
 fn app_pages_third_run_rollbacks_to_after_first_run() {
     // 1st run
     let pages_count = 3;
-    let addr = 0x11_22_33_44;
+    let addr = "my-app";
 
     let (addr, kv, mut pages) = app_pages_init(addr, pages_count);
 

--- a/crates/svm-storage/tests/app_storage_tests.rs
+++ b/crates/svm-storage/tests/app_storage_tests.rs
@@ -7,7 +7,7 @@ mod asserts;
 
 #[test]
 fn app_storage_loading_an_empty_slice_into_the_cache() {
-    let addr = 0x11_22_33_44;
+    let addr = "my-app";
     let pages_count = 10;
 
     let (_addr, _kv, mut storage) = app_storage_init(addr, pages_count);
@@ -19,7 +19,7 @@ fn app_storage_loading_an_empty_slice_into_the_cache() {
 
 #[test]
 fn app_storage_read_an_empty_slice_then_override_it_and_then_commit() {
-    let addr = 0x11_22_33_44;
+    let addr = "my-app";
     let pages_count = 10;
 
     let (addr, kv, mut storage) = app_storage_init(addr, pages_count);
@@ -39,7 +39,7 @@ fn app_storage_read_an_empty_slice_then_override_it_and_then_commit() {
 
 #[test]
 fn app_storage_write_slice_without_loading_it_first_and_commit() {
-    let addr = 0x11_22_33_44;
+    let addr = "my-app";
     let pages_count = 2;
 
     let (addr, kv, mut storage) = app_storage_init(addr, pages_count);
@@ -65,7 +65,7 @@ fn app_storage_write_slice_without_loading_it_first_and_commit() {
 
 #[test]
 fn app_storage_read_an_existing_slice_then_overriding_it_and_commit() {
-    let addr = 0x11_22_33_44;
+    let addr = "my-app";
     let pages_count = 2;
 
     let (addr, kv, mut storage) = app_storage_init(addr, pages_count);
@@ -102,7 +102,7 @@ fn app_storage_read_an_existing_slice_then_overriding_it_and_commit() {
 
 #[test]
 fn app_storage_write_slice_and_commit_then_load_it_override_it_and_commit() {
-    let addr = 0x11_22_33_44;
+    let addr = "my-app";
     let pages_count = 2;
 
     let (addr, kv, mut storage) = app_storage_init(addr, pages_count);
@@ -141,7 +141,7 @@ fn app_storage_write_slice_and_commit_then_load_it_override_it_and_commit() {
 
 #[test]
 fn app_storage_write_two_slices_under_same_page_and_commit() {
-    let addr = 0x11_22_33_44;
+    let addr = "my-app";
     let pages_count = 2;
 
     let (addr, kv, mut storage) = app_storage_init(addr, pages_count);


### PR DESCRIPTION
Adding a helper method `Address::from(&str)` will make the tests look more intuitive.

We can then be have in our tests this:
```
let author = Address::from("@author");
let sender = Address::from("@sender");
```