### PR TITLE
vmcalls i32 i64

### DIFF
--- a/crates/svm-runtime-c-api/tests/api_tests.rs
+++ b/crates/svm-runtime-c-api/tests/api_tests.rs
@@ -255,11 +255,13 @@ unsafe fn do_ffi_exec_app() {
     let init_balance = 100;
     host.set_balance(&user, init_balance);
 
-    // let nonce = 3;
-    // let nonce_vec = vec![0, 0, 0, 0, 0, 0, 0, nonce];
+    let nonce = 3;
+    let nonce_idx = 2;
+    let nonce_vec = vec![0, 0, 0, 0, 0, 0, 0, nonce];
 
     // we set field index `2` with a value called `nonce` (one byte).
-    let (host_ctx_bytes, host_ctx_len) = host_ctx_bytes(version, hashmap! {});
+    let (host_ctx_bytes, host_ctx_len) =
+        host_ctx_bytes(version, hashmap! { nonce_idx => nonce_vec });
 
     let mut receipt = std::ptr::null_mut();
     let mut receipt_length = 0;

--- a/crates/svm-runtime-c-api/tests/api_tests.rs
+++ b/crates/svm-runtime-c-api/tests/api_tests.rs
@@ -12,6 +12,7 @@ use svm_app::types::WasmValue;
 use svm_common::{Address, State};
 use svm_runtime::register::Register;
 
+#[derive(Debug)]
 struct Host {
     balance: HashMap<Address, i128>,
 }
@@ -23,6 +24,10 @@ impl Host {
         }
     }
 
+    fn set_balance(&mut self, addr: &Address, init: i128) {
+        self.balance.insert(addr.clone(), init);
+    }
+
     fn get_balance(&self, addr: &Address) -> Option<i128> {
         self.balance.get(addr).copied()
     }
@@ -31,6 +36,14 @@ impl Host {
         let balance = self.get_balance(addr).unwrap_or(0);
 
         let new_balance = balance + addition as i128;
+
+        self.balance.insert(addr.clone(), new_balance);
+    }
+
+    fn mul_balance(&mut self, addr: &Address, mul_by: i64) {
+        let balance = self.get_balance(addr).unwrap_or(0);
+
+        let new_balance = balance * mul_by as i128;
 
         self.balance.insert(addr.clone(), new_balance);
     }
@@ -61,8 +74,16 @@ unsafe extern "C" fn inc_balance(ctx: *mut c_void, reg_bits: i32, reg_idx: i32, 
     host.inc_balance(&addr, addition);
 }
 
+unsafe extern "C" fn mul_balance(ctx: *mut c_void, reg_bits: i32, reg_idx: i32, mul_by: i64) {
+    let host = extract_host(ctx);
+    let reg = extract_reg(ctx, reg_bits, reg_idx);
+
+    let addr = Address::from(reg.as_ptr());
+    host.mul_balance(&addr, mul_by);
+}
+
 unsafe fn create_imports() -> (Vec<*const svm_import_t>, u32) {
-    let set_balance_import = testing::import_func_create(
+    let inc_balance_import = testing::import_func_create(
         "env",
         "inc_balance",
         inc_balance as _,
@@ -74,7 +95,19 @@ unsafe fn create_imports() -> (Vec<*const svm_import_t>, u32) {
         vec![],
     );
 
-    let imports = vec![inc_balance_import];
+    let mul_balance_import = testing::import_func_create(
+        "env",
+        "mul_balance",
+        mul_balance as _,
+        vec![
+            svm_value_type::SVM_I32,
+            svm_value_type::SVM_I32,
+            svm_value_type::SVM_I64,
+        ],
+        vec![],
+    );
+
+    let imports = vec![inc_balance_import, mul_balance_import];
     let imports_len = imports.len() as u32;
 
     (imports, imports_len)
@@ -124,122 +157,125 @@ fn host_ctx_bytes(version: u32, fields: HashMap<i32, Vec<u8>>) -> (Vec<u8>, u32)
     (bytes, bytes_len)
 }
 
-fn exec_app_args() -> (Address, i64, Vec<Vec<u8>>, Vec<WasmValue>, State) {
+fn exec_app_args() -> (Address, Address, i64, Vec<Vec<u8>>, Vec<WasmValue>, State) {
     let sender = Address::of("sender");
-    let mul_by = 3;
-    let func_buf = vec![];
-    let func_args = vec![WasmValue::I64(mul_by)];
+
+    let user = Address::of("user");
+    let user_bytes = user.bytes().to_vec();
+    let func_buf = vec![user_bytes];
+
+    let arg_val = 2;
+    let func_args = vec![WasmValue::I64(arg_val)];
+
     let state = State::empty();
 
-    (sender, mul_by, func_buf, func_args, state)
+    (sender, user, arg_val, func_buf, func_args, state)
 }
 
-// #[test]
-// fn runtime_ffi_exec_app() {
-//     unsafe {
-//         do_ffi_exec_app();
-//     }
-// }
-//
-// unsafe fn do_ffi_exec_app() {
-//     let version: u32 = 0;
-//
-//     // 1) init runtime
-//     let mut host = Host::new();
-//     let mut kv = std::ptr::null_mut();
-//     let mut runtime = std::ptr::null_mut();
-//     let (imports, imports_len) = create_imports();
-//
-//     testing::svm_memory_kv_create(&mut kv);
-//
-//     let res = testing::svm_memory_runtime_create(
-//         &mut runtime,
-//         kv,
-//         host.as_mut_ptr(),
-//         imports.as_ptr(),
-//         imports_len,
-//     );
-//     assert_eq!(true, res.as_bool());
-//
-//     // 2) deploy app-template
-//     let author = Address::of("author");
-//     let code = include_str!("wasm/update-balance.wast");
-//     let page_count = 10;
-//     let (hctx_bytes, hctx_len) = host_ctx_bytes(version, hashmap! {});
-//     let (bytes, bytes_len) = deploy_template_bytes(version, "MyTemplate #1", page_count, code);
-//     let mut template = std::ptr::null_mut();
-//
-//     let res = api::svm_deploy_template(
-//         &mut template,
-//         runtime,
-//         author.as_ptr() as _,
-//         hctx_bytes.as_ptr() as _,
-//         hctx_len as _,
-//         bytes.as_ptr() as _,
-//         bytes_len,
-//     );
-//     assert_eq!(true, res.as_bool());
-//
-//     // 3) spawn app
-//     let mut app_addr = std::ptr::null_mut();
-//     let creator = Address::of("creator");
-//     let ctor_buf = vec![];
-//     let ctor_args = vec![];
-//     let (hctx_bytes, hctx_len) = host_ctx_bytes(version, hashmap! {});
-//     let (bytes, bytes_len) = spawn_app_bytes(version, template as _, &ctor_buf, &ctor_args);
-//     let res = api::svm_spawn_app(
-//         &mut app_addr,
-//         runtime,
-//         creator.as_ptr() as _,
-//         hctx_bytes.as_ptr() as _,
-//         hctx_len as _,
-//         bytes.as_ptr() as _,
-//         bytes_len,
-//     );
-//     assert_eq!(true, res.as_bool());
-//
-//     // 3) execute app
-//     let (sender, mul_by, func_buf, func_args, state) = exec_app_args();
-//     let (bytes, bytes_len) = exec_app_bytes(version, app_addr, "run", &func_buf, &func_args);
-//
-//     // 3.1) parse bytes into in-memory `AppTransaction`
-//     let mut app_tx = std::ptr::null_mut();
-//     let res = api::svm_parse_exec_app(
-//         &mut app_tx,
-//         runtime,
-//         sender.as_ptr() as _,
-//         bytes.as_ptr() as _,
-//         bytes_len,
-//     );
-//     assert_eq!(true, res.as_bool());
-//
-//     // 3.2) execute the app-transaction
-//     // initialize `address=0x10_20_30` with balance=100
-//     let user = Address::of("user");
-//     let initial_balance = 100;
-//     host.set_balance(&user), initial_balance);
-//
-//     let delta = 50;
-//     let delta_vec = vec![0, 0, 0, 0, 0, 0, 0, delta];
-//
-//     // we set field index `2` with a value called `delta` (one byte).
-//     let (host_ctx_bytes, host_ctx_len) = host_ctx_bytes(version, hashmap! { 2 => delta_vec });
-//
-//     let mut receipt = std::ptr::null_mut();
-//     let mut receipt_length = 0;
-//     let res = api::svm_exec_app(
-//         &mut receipt,
-//         &mut receipt_length,
-//         runtime,
-//         app_tx,
-//         svm_common::into_raw(state),
-//         host_ctx_bytes.as_ptr() as _,
-//         host_ctx_len as _,
-//     );
-//     assert_eq!(true, res.as_bool());
-//
-//     let expected = initial_balance * mul_by + (delta as i64);
-//     let actual = host.get_balance(&user).unwrap();
-//
-//     assert_eq!(expected, actual);
-// }
+#[test]
+fn runtime_ffi_exec_app() {
+    unsafe {
+        do_ffi_exec_app();
+    }
+}
+
+unsafe fn do_ffi_exec_app() {
+    let version: u32 = 0;
+
+    // 1) init runtime
+    let mut host = Host::new();
+    let mut kv = std::ptr::null_mut();
+    let mut runtime = std::ptr::null_mut();
+    let (imports, imports_len) = create_imports();
+
+    testing::svm_memory_kv_create(&mut kv);
+
+    let res = testing::svm_memory_runtime_create(
+        &mut runtime,
+        kv,
+        host.as_mut_ptr(),
+        imports.as_ptr(),
+        imports_len,
+    );
+    assert_eq!(true, res.as_bool());
+
+    // 2) deploy app-template
+    let author = Address::of("author");
+    let code = include_str!("wasm/update-balance.wast");
+    let page_count = 10;
+    let (hctx_bytes, hctx_len) = host_ctx_bytes(version, hashmap! {});
+    let (bytes, bytes_len) = deploy_template_bytes(version, "MyTemplate #1", page_count, code);
+    let mut template = std::ptr::null_mut();
+
+    let res = api::svm_deploy_template(
+        &mut template,
+        runtime,
+        author.as_ptr() as _,
+        hctx_bytes.as_ptr() as _,
+        hctx_len as _,
+        bytes.as_ptr() as _,
+        bytes_len,
+    );
+    assert_eq!(true, res.as_bool());
+
+    // 3) spawn app
+    let mut app_addr = std::ptr::null_mut();
+    let creator = Address::of("creator");
+    let ctor_buf = vec![];
+    let ctor_args = vec![];
+    let (hctx_bytes, hctx_len) = host_ctx_bytes(version, hashmap! {});
+    let (bytes, bytes_len) = spawn_app_bytes(version, template as _, &ctor_buf, &ctor_args);
+    let res = api::svm_spawn_app(
+        &mut app_addr,
+        runtime,
+        creator.as_ptr() as _,
+        hctx_bytes.as_ptr() as _,
+        hctx_len as _,
+        bytes.as_ptr() as _,
+        bytes_len,
+    );
+    assert_eq!(true, res.as_bool());
+
+    // 4) execute app
+    let (sender, user, arg_val, func_buf, func_args, state) = exec_app_args();
+    let (bytes, bytes_len) = exec_app_bytes(version, app_addr, "run", &func_buf, &func_args);
+
+    // 4.1) parse bytes into in-memory `AppTransaction`
+    let mut app_tx = std::ptr::null_mut();
+    let res = api::svm_parse_exec_app(
+        &mut app_tx,
+        runtime,
+        sender.as_ptr() as _,
+        bytes.as_ptr() as _,
+        bytes_len,
+    );
+    assert_eq!(true, res.as_bool());
+
+    // 4.2) execute the app-transaction
+    let init_balance = 100;
+    host.set_balance(&user, init_balance);
+
+    // let nonce = 3;
+    // let nonce_vec = vec![0, 0, 0, 0, 0, 0, 0, nonce];
+
+    // we set field index `2` with a value called `nonce` (one byte).
+    let (host_ctx_bytes, host_ctx_len) = host_ctx_bytes(version, hashmap! {});
+
+    let mut receipt = std::ptr::null_mut();
+    let mut receipt_length = 0;
+    let res = api::svm_exec_app(
+        &mut receipt,
+        &mut receipt_length,
+        runtime,
+        app_tx,
+        svm_common::into_raw(state),
+        host_ctx_bytes.as_ptr() as _,
+        host_ctx_len as _,
+    );
+    assert_eq!(true, res.as_bool());
+
+    let expected = init_balance + arg_val as i128;
+    let actual = host.get_balance(&user).unwrap();
+
+    assert_eq!(expected, actual);
+}

--- a/crates/svm-runtime-c-api/tests/wasm/update-balance.wast
+++ b/crates/svm-runtime-c-api/tests/wasm/update-balance.wast
@@ -1,21 +1,37 @@
 (module
   ;; `SVM` vmcalls
-  (func $host_ctx_read_into_reg (import "svm" "host_ctx_read_into_reg") (param i32 i32 i32))
+  (func $reg_push (import "svm" "reg_push") (param i32 i32))
+  (func $reg_pop (import "svm" "reg_pop") (param i32 i32))
+  (func $buffer_copy_to_reg (import "svm" "buffer_copy_to_reg") (param i32 i32 i32 i32 i32))
+  (; (func $host_ctx_read_into_reg (import "svm" "host_ctx_read_into_reg") (param i32 i32 i32)) ;)
 
   ;; host vmcalls
-  (; (func $save_balance (import "env" "save_balance") (param i32 i32)) ;)
   (func $inc_balance (import "env" "inc_balance") (param i32 i32 i64))
+  (func $mult_balance (import "env" "mul_balance") (param i32 i32 i64))
 
   (memory 1)  ;; memory `0` (default) is initialized with one page
 
-  (func (export "run") (param)
-        ;; reg_push(i32, i32)
+  (func (export "run") (param i64)
+        ;; save register `160:0`
+        i32.const 160 ;; reg_bits
+        i32.const 0   ;; reg_idx
+        call $reg_push
+
         ;; copy input `Address` (given in func-buffer) into register
+        i32.const 0    ;; buf_id
+        i32.const 0    ;; buf_offset
+        i32.const 160  ;; reg_bits
+        i32.const 0    ;; reg_idx
+        i32.const 20   ;; count (`Address` consumes 20 bytes)
+        call $buffer_copy_to_reg
 
-        ;; increment the `Address` balance
+        ;; update the `Address` balance (under register `160:0`)
+        i32.const 160 ;; reg_bits
+        i32.const 0   ;; reg_idx
+        get_local 0   ;; addition
+        call $inc_balance
 
-        ;; add `delta` to balance (passed via `HostCtx` parameters)
-
-        ;; reg_pop(i32, i32)
-
-        (nop))
+        ;; restore register `160:0`
+        i32.const 160 ;; reg_bits
+        i32.const 0   ;; reg_idx
+        call $reg_pop))

--- a/crates/svm-runtime-c-api/tests/wasm/update-balance.wast
+++ b/crates/svm-runtime-c-api/tests/wasm/update-balance.wast
@@ -25,11 +25,23 @@
         i32.const 20   ;; count (`Address` consumes 20 bytes)
         call $buffer_copy_to_reg
 
+        ;; load `nonce` from `HostCtx` into `i64`
+
         ;; update the `Address` balance (under register `160:0`)
+        ;; if `nonce` is greater than 10, we'll call `inc_balance`,
+        ;; otherwise, we'll call `mul_balance`
+
+        ????
+
         i32.const 160 ;; reg_bits
         i32.const 0   ;; reg_idx
         get_local 0   ;; addition
         call $inc_balance
+
+        i32.const 160 ;; reg_bits
+        i32.const 0   ;; reg_idx
+        get_local 0   ;; mul-by
+        call $mul_balance
 
         ;; restore register `160:0`
         i32.const 160 ;; reg_bits

--- a/crates/svm-runtime-c-api/tests/wasm/update-balance.wast
+++ b/crates/svm-runtime-c-api/tests/wasm/update-balance.wast
@@ -3,50 +3,19 @@
   (func $host_ctx_read_into_reg (import "svm" "host_ctx_read_into_reg") (param i32 i32 i32))
 
   ;; host vmcalls
-  (func $save_balance (import "env" "save_balance") (param i32 i32) (result i64))
-  (func $inc_balance (import "env" "inc_balance") (param i32 i32))
+  (; (func $save_balance (import "env" "save_balance") (param i32 i32)) ;)
+  (func $inc_balance (import "env" "inc_balance") (param i32 i32 i64))
 
   (memory 1)  ;; memory `0` (default) is initialized with one page
 
-  ;; exported function to be called
-  (func (export "run") (param i64)
-        ;; reset register `160:0` with `00...0`
-        i64.const 0
-        i32.const 160
-        i32.const 0
-        call $reg_write_be_i64
+  (func (export "run") (param)
+        ;; reg_push(i32, i32)
+        ;; copy input `Address` (given in func-buffer) into register
 
-        ;; read current balance of address `0x000...00_10_20_30`
-        i32.const 160 ;; reg_bits
-        i32.const 0   ;; reg_idx
-        call $get_balance
+        ;; increment the `Address` balance
 
-        ;; here the top of the stack has the balance of account `0x000...00_10_20_30`
+        ;; add `delta` to balance (passed via `HostCtx` parameters)
 
-        ;; multiply account `0x000...00_10_20_30` balance by input `mul_by` param
-        get_local 0
-        i64.mul
+        ;; reg_pop(i32, i32)
 
-        i32.const 2   ;; field #2
-        i32.const 64  ;; reg 64-bits
-        i32.const 3   ;; reg #3
-        call $host_ctx_read_into_reg
-
-        ;; now we'll interpret register `64:3` (contains the content of host-ctx field `2`)
-        ;; as a 64-bit BigEndian number (this is the `delta`).
-        i32.const 64
-        i32.const 3
-        call $reg_read_be_i64
-
-        ;; here the top of the stack is:
-        ;; `delta` (i64)
-        ;; `account balace` (i64)
-
-        ;; we're adding `delta` to the account balance
-        i64.add
-
-        ;; now the top of the stack holds the new balance.
-        ;; we'll persist address `0x000...00_10_20_30` (the value of register `160:0`) with the new balance.
-        i32.const 160 ;; reg_bits
-        i32.const 0   ;; reg_idx
-        call $set_balance))
+        (nop))

--- a/crates/svm-runtime/src/runtime/default.rs
+++ b/crates/svm-runtime/src/runtime/default.rs
@@ -222,23 +222,6 @@ where
         Ok(receipt)
     }
 
-    fn make_receipt(&self, result: Result<(State, Vec<Value>), ExecAppError>) -> Receipt {
-        match result {
-            Err(e) => Receipt {
-                success: false,
-                error: Some(e),
-                returns: None,
-                new_state: None,
-            },
-            Ok((state, returns)) => Receipt {
-                success: true,
-                error: None,
-                returns: Some(returns),
-                new_state: Some(state),
-            },
-        }
-    }
-
     fn do_exec_app(
         &self,
         tx: &AppTransaction,
@@ -279,6 +262,23 @@ where
 
                 Ok((new_state, returns))
             }
+        }
+    }
+
+    fn make_receipt(&self, result: Result<(State, Vec<Value>), ExecAppError>) -> Receipt {
+        match result {
+            Err(e) => Receipt {
+                success: false,
+                error: Some(e),
+                returns: None,
+                new_state: None,
+            },
+            Ok((state, returns)) => Receipt {
+                success: true,
+                error: None,
+                returns: Some(returns),
+                new_state: Some(state),
+            },
         }
     }
 

--- a/crates/svm-runtime/src/runtime/default.rs
+++ b/crates/svm-runtime/src/runtime/default.rs
@@ -214,25 +214,29 @@ where
         let mut import_object = self.import_object_create(&tx.app, &state, host_ctx, &settings);
         self.import_object_extend(&mut import_object);
 
-        let receipt =
-            match self.do_exec_app(&tx, &template, &template_addr, &import_object, is_ctor) {
-                Err(e) => Receipt {
-                    success: false,
-                    error: Some(e),
-                    returns: None,
-                    new_state: None,
-                },
-                Ok((state, returns)) => Receipt {
-                    success: true,
-                    error: None,
-                    returns: Some(returns),
-                    new_state: Some(state),
-                },
-            };
+        let result = self.do_exec_app(&tx, &template, &template_addr, &import_object, is_ctor);
+        let receipt = self.make_receipt(result);
 
         info!("receipt: {:?}", receipt);
 
         Ok(receipt)
+    }
+
+    fn make_receipt(&self, result: Result<(State, Vec<Value>), ExecAppError>) -> Receipt {
+        match result {
+            Err(e) => Receipt {
+                success: false,
+                error: Some(e),
+                returns: None,
+                new_state: None,
+            },
+            Ok((state, returns)) => Receipt {
+                success: true,
+                error: None,
+                returns: Some(returns),
+                new_state: Some(state),
+            },
+        }
     }
 
     fn do_exec_app(

--- a/crates/svm-runtime/src/vmcalls/buffer.rs
+++ b/crates/svm-runtime/src/vmcalls/buffer.rs
@@ -1,19 +1,21 @@
 use crate::{buffer::Buffer, ctx::SvmCtx, helpers};
 
-pub fn buffer_create(ctx: &mut wasmer_runtime::Ctx, buf_id: i32, capacity: i32) {
+use wasmer_runtime::Ctx as WasmerCtx;
+
+pub fn buffer_create(ctx: &mut WasmerCtx, buf_id: i32, capacity: i32) {
     helpers::buffer_create(ctx.data, buf_id, capacity)
 }
 
-pub fn buffer_kill(ctx: &mut wasmer_runtime::Ctx, buf_id: i32) {
+pub fn buffer_kill(ctx: &mut WasmerCtx, buf_id: i32) {
     helpers::buffer_kill(ctx.data, buf_id);
 }
 
-pub fn buffer_freeze(ctx: &mut wasmer_runtime::Ctx, buf_id: i32) {
+pub fn buffer_freeze(ctx: &mut WasmerCtx, buf_id: i32) {
     helpers::buffer_freeze(ctx.data, buf_id);
 }
 
 pub fn buffer_copy_to_storage(
-    ctx: &mut wasmer_runtime::Ctx,
+    ctx: &mut WasmerCtx,
     buf_id: i32,
     buf_offset: i32,
     page_idx: i32,
@@ -24,7 +26,7 @@ pub fn buffer_copy_to_storage(
 }
 
 pub fn buffer_copy_to_reg(
-    ctx: &mut wasmer_runtime::Ctx,
+    ctx: &mut WasmerCtx,
     buf_id: i32,
     buf_offset: i32,
     reg_bits: i32,
@@ -32,26 +34,4 @@ pub fn buffer_copy_to_reg(
     count: i32,
 ) {
     helpers::buffer_copy_to_reg(ctx.data, buf_id, buf_offset, reg_bits, reg_idx, count);
-}
-
-pub fn buffer_copy_to_i32_le(
-    ctx: &mut wasmer_runtime::Ctx,
-    buf_id: i32,
-    buf_offset: i32,
-    count: i32,
-) {
-    //
-}
-
-pub fn buffer_copy_to_i32_be(
-    ctx: &mut wasmer_runtime::Ctx,
-    buf_id: i32,
-    buf_offset: i32,
-    count: i32,
-) {
-    //
-}
-
-pub fn buffer_copy_to_i64(ctx: &mut wasmer_runtime::Ctx, buf_id: i32, buf_offset: i32, count: i32) {
-    //
 }

--- a/crates/svm-runtime/src/vmcalls/buffer.rs
+++ b/crates/svm-runtime/src/vmcalls/buffer.rs
@@ -33,3 +33,25 @@ pub fn buffer_copy_to_reg(
 ) {
     helpers::buffer_copy_to_reg(ctx.data, buf_id, buf_offset, reg_bits, reg_idx, count);
 }
+
+pub fn buffer_copy_to_i32_le(
+    ctx: &mut wasmer_runtime::Ctx,
+    buf_id: i32,
+    buf_offset: i32,
+    count: i32,
+) {
+    //
+}
+
+pub fn buffer_copy_to_i32_be(
+    ctx: &mut wasmer_runtime::Ctx,
+    buf_id: i32,
+    buf_offset: i32,
+    count: i32,
+) {
+    //
+}
+
+pub fn buffer_copy_to_i64(ctx: &mut wasmer_runtime::Ctx, buf_id: i32, buf_offset: i32, count: i32) {
+    //
+}

--- a/crates/svm-runtime/src/vmcalls/host_ctx.rs
+++ b/crates/svm-runtime/src/vmcalls/host_ctx.rs
@@ -1,12 +1,9 @@
 use crate::{ctx::SvmCtx, helpers};
 
+use wasmer_runtime::Ctx as WasmerCtx;
+
 /// Reads host context field with index `field_idx` into register `{reg_bits}:{reg_idx}`
-pub fn host_ctx_read_into_reg(
-    ctx: &mut wasmer_runtime::Ctx,
-    field_idx: i32,
-    reg_bits: i32,
-    reg_idx: i32,
-) {
+pub fn host_ctx_read_into_reg(ctx: &mut WasmerCtx, field_idx: i32, reg_bits: i32, reg_idx: i32) {
     let svm_ctx = unsafe { svm_common::from_raw_mut::<SvmCtx>(ctx.data) };
     let host_ctx = unsafe { &*(svm_ctx.host_ctx) };
 
@@ -14,4 +11,32 @@ pub fn host_ctx_read_into_reg(
     let slice = host_ctx.get(field_idx).unwrap();
 
     reg.set(slice);
+}
+
+pub fn host_ctx_read_i8(ctx: &mut WasmerCtx, field_idx: i32) -> i32 {
+    todo!()
+}
+
+pub fn host_ctx_read_i16_le(ctx: &mut WasmerCtx, field_idx: i32) -> i32 {
+    todo!()
+}
+
+pub fn host_ctx_read_i16_be(ctx: &mut WasmerCtx, field_idx: i32) -> i32 {
+    todo!()
+}
+
+pub fn host_ctx_read_i32_le(ctx: &mut WasmerCtx, field_idx: i32) -> i32 {
+    todo!()
+}
+
+pub fn host_ctx_read_i32_be(ctx: &mut WasmerCtx, field_idx: i32) -> i32 {
+    todo!()
+}
+
+pub fn host_ctx_read_i64_le(ctx: &mut WasmerCtx, field_idx: i32) -> i64 {
+    todo!()
+}
+
+pub fn host_ctx_read_i64_be(ctx: &mut WasmerCtx, field_idx: i32) -> i64 {
+    todo!()
 }

--- a/crates/svm-runtime/src/vmcalls/mod.rs
+++ b/crates/svm-runtime/src/vmcalls/mod.rs
@@ -1,11 +1,13 @@
 mod buffer;
 mod host_ctx;
+mod register;
 mod storage;
 
 pub use buffer::{
     buffer_copy_to_reg, buffer_copy_to_storage, buffer_create, buffer_freeze, buffer_kill,
 };
 pub use host_ctx::host_ctx_read_into_reg;
+pub use register::{reg_pop, reg_push};
 pub use storage::{
     mem_to_reg_copy, reg_to_mem_copy, storage_read_to_mem, storage_read_to_reg,
     storage_write_from_mem, storage_write_from_reg,
@@ -37,7 +39,11 @@ pub fn insert_vmcalls(ns: &mut Namespace) {
         func!(storage::storage_write_from_reg),
     );
 
-    // `buffer` vmcalls`
+    // `register` vmcalls
+    ns.insert("reg_push", func!(reg_push));
+    ns.insert("reg_pop", func!(reg_pop));
+
+    // `buffer` vmcalls
     ns.insert("buffer_create", func!(buffer::buffer_create));
     ns.insert("buffer_kill", func!(buffer::buffer_kill));
     ns.insert("buffer_freeze", func!(buffer::buffer_freeze));

--- a/crates/svm-runtime/src/vmcalls/mod.rs
+++ b/crates/svm-runtime/src/vmcalls/mod.rs
@@ -9,7 +9,8 @@ pub use buffer::{
 pub use host_ctx::host_ctx_read_into_reg;
 pub use register::{reg_pop, reg_push};
 pub use storage::{
-    mem_to_reg_copy, reg_to_mem_copy, storage_read_to_mem, storage_read_to_reg,
+    mem_to_reg_copy, reg_to_mem_copy, storage_read_i32_be, storage_read_i32_le,
+    storage_read_i64_be, storage_read_i64_le, storage_read_to_mem, storage_read_to_reg,
     storage_write_from_mem, storage_write_from_reg,
 };
 
@@ -38,6 +39,11 @@ pub fn insert_vmcalls(ns: &mut Namespace) {
         "storage_write_from_reg",
         func!(storage::storage_write_from_reg),
     );
+
+    ns.insert("storage_read_i32_le", func!(storage::storage_read_i32_le));
+    ns.insert("storage_read_i32_be", func!(storage::storage_read_i32_be));
+    ns.insert("storage_read_i64_le", func!(storage::storage_read_i64_le));
+    ns.insert("storage_read_i64_be", func!(storage::storage_read_i64_be));
 
     // `register` vmcalls
     ns.insert("reg_push", func!(reg_push));

--- a/crates/svm-runtime/src/vmcalls/register.rs
+++ b/crates/svm-runtime/src/vmcalls/register.rs
@@ -1,0 +1,13 @@
+use crate::helpers;
+
+#[inline]
+pub fn reg_push(ctx: &mut wasmer_runtime::Ctx, reg_bits: i32, reg_idx: i32) {
+    let reg = helpers::wasmer_data_reg(ctx.data, reg_bits, reg_idx);
+    reg.push();
+}
+
+#[inline]
+pub fn reg_pop(ctx: &mut wasmer_runtime::Ctx, reg_bits: i32, reg_idx: i32) {
+    let reg = helpers::wasmer_data_reg(ctx.data, reg_bits, reg_idx);
+    reg.pop();
+}

--- a/crates/svm-runtime/src/vmcalls/register.rs
+++ b/crates/svm-runtime/src/vmcalls/register.rs
@@ -1,13 +1,15 @@
 use crate::helpers;
 
+use wasmer_runtime::Ctx as WasmerCtx;
+
 #[inline]
-pub fn reg_push(ctx: &mut wasmer_runtime::Ctx, reg_bits: i32, reg_idx: i32) {
+pub fn reg_push(ctx: &mut WasmerCtx, reg_bits: i32, reg_idx: i32) {
     let reg = helpers::wasmer_data_reg(ctx.data, reg_bits, reg_idx);
     reg.push();
 }
 
 #[inline]
-pub fn reg_pop(ctx: &mut wasmer_runtime::Ctx, reg_bits: i32, reg_idx: i32) {
+pub fn reg_pop(ctx: &mut WasmerCtx, reg_bits: i32, reg_idx: i32) {
     let reg = helpers::wasmer_data_reg(ctx.data, reg_bits, reg_idx);
     reg.pop();
 }

--- a/crates/svm-runtime/tests/vmcalls.rs
+++ b/crates/svm-runtime/tests/vmcalls.rs
@@ -423,7 +423,7 @@ fn vmcalls_register_pop() {
     reg.set(&data[..]);
     reg.push();
 
-    // will call `reg_push` on input register
+    // will call `reg_pop` on input register
     let func: Func<(i32, i32)> = instance.func("run").unwrap();
     assert!(func.call(reg_bits, reg_idx).is_ok());
 

--- a/crates/svm-runtime/tests/vmcalls.rs
+++ b/crates/svm-runtime/tests/vmcalls.rs
@@ -522,3 +522,189 @@ fn vmcalls_buffer_copy_to_storage() {
         helpers::storage_read_page_slice(storage, page_idx, page_offset, count)
     );
 }
+
+macro_rules! assert_int {
+    ($expected:expr, $func:expr, $page_idx:expr, $page_offset:expr, $count:expr, $endianness:expr) => {{
+        let actual = $func
+            .call($page_idx, $page_offset, $count, $endianness)
+            .unwrap();
+
+        assert_eq!($expected, actual);
+    }};
+}
+
+#[test]
+fn vmcalls_storage_read_int() {
+    let big_endian = 1;
+    let little_endian = 0;
+
+    let slices = vec![
+        (0, 0, vec![0x10]),
+        (0, 1, vec![0x10, 0x20]),
+        (0, 3, vec![0x10, 0x20, 0x30]),
+        (0, 6, vec![0x10, 0x20, 0x30, 0x40]),
+        (1, 0, vec![0x10, 0x20, 0x30, 0x40, 0x50]),
+        (1, 5, vec![0x10, 0x20, 0x30, 0x40, 0x50, 0x60]),
+        (2, 0, vec![0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70]),
+        (2, 7, vec![0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80]),
+    ];
+
+    let (app_addr, state, host, host_ctx, page_count) = default_test_args();
+
+    let import_object = imports! {
+        move || testing::app_memory_state_creator(&app_addr, &state, host, host_ctx, page_count),
+
+        "svm" => {
+            "storage_read_i32_be" => func!(vmcalls::storage_read_i32_be),
+            "storage_read_i32_le" => func!(vmcalls::storage_read_i32_le),
+            "storage_read_i64_be" => func!(vmcalls::storage_read_i64_be),
+            "storage_read_i64_le" => func!(vmcalls::storage_read_i64_le),
+        },
+    };
+
+    let instance = testing::instantiate(&import_object, include_str!("wasm/storage_read_int.wast"));
+
+    let storage = instance_storage(&instance);
+
+    for (page_idx, page_offset, data) in slices.iter() {
+        let layout = PageSliceLayout::new(
+            PageIndex(*page_idx as u16),
+            PageOffset(*page_offset as u32),
+            data.len() as u32,
+        );
+        storage.write_page_slice(&layout, &data[..]);
+    }
+
+    let func: Func<(i32, i32, i32, i32), i32> = instance.func("read_i32").unwrap();
+
+    // slice #0: `(0, 0, vec![0])`
+    let (page_idx, page_offset, count) = (slices[0].0, slices[0].1, slices[0].2.len() as i32);
+
+    assert_int!(0x10, func, page_idx, page_offset, count, big_endian);
+    assert_int!(0x10, func, page_idx, page_offset, count, little_endian);
+
+    // slice #1: `(0, 1, vec![0x10, 0x20])`
+    let (page_idx, page_offset, count) = (slices[1].0, slices[1].1, slices[1].2.len() as i32);
+    assert_int!(0x10_20, func, page_idx, page_offset, count, big_endian);
+    assert_int!(0x20_10, func, page_idx, page_offset, count, little_endian);
+
+    // slice #2: `(0, 3, vec![0x10, 0x20, 0x30])`
+    let (page_idx, page_offset, count) = (slices[2].0, slices[2].1, slices[2].2.len() as i32);
+
+    assert_int!(0x10_20_30, func, page_idx, page_offset, count, big_endian);
+    assert_int!(
+        0x30_20_10,
+        func,
+        page_idx,
+        page_offset,
+        count,
+        little_endian
+    );
+
+    // slice #3: `(0, 6, vec![0x10, 0x20, 0x30, 0x40])`
+    let (page_idx, page_offset, count) = (slices[3].0, slices[3].1, slices[3].2.len() as i32);
+
+    assert_int!(
+        0x10_20_30_40,
+        func,
+        page_idx,
+        page_offset,
+        count,
+        big_endian
+    );
+
+    assert_int!(
+        0x40_30_20_10,
+        func,
+        page_idx,
+        page_offset,
+        count,
+        little_endian
+    );
+
+    let func: Func<(i32, i32, i32, i32), u64> = instance.func("read_i64").unwrap();
+
+    // slice #4: `(1, 0, vec![0x10, 0x20, 0x30, 0x40, 0x50])`
+    let (page_idx, page_offset, count) = (slices[4].0, slices[4].1, slices[4].2.len() as i32);
+
+    assert_int!(
+        0x10_20_30_40_50,
+        func,
+        page_idx,
+        page_offset,
+        count,
+        big_endian
+    );
+
+    assert_int!(
+        0x50_40_30_20_10,
+        func,
+        page_idx,
+        page_offset,
+        count,
+        little_endian
+    );
+
+    // slice #5: `(1, 5, vec![0x10, 0x20, 0x30, 0x40, 0x50, 0x60])`
+    let (page_idx, page_offset, count) = (slices[5].0, slices[5].1, slices[5].2.len() as i32);
+
+    assert_int!(
+        0x10_20_30_40_50_60,
+        func,
+        page_idx,
+        page_offset,
+        count,
+        big_endian
+    );
+
+    assert_int!(
+        0x60_50_40_30_20_10,
+        func,
+        page_idx,
+        page_offset,
+        count,
+        little_endian
+    );
+
+    // slice #6: `(2, 0, vec![0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70])`
+    let (page_idx, page_offset, count) = (slices[6].0, slices[6].1, slices[6].2.len() as i32);
+
+    assert_int!(
+        0x10_20_30_40_50_60_70,
+        func,
+        page_idx,
+        page_offset,
+        count,
+        big_endian
+    );
+
+    assert_int!(
+        0x70_60_50_40_30_20_10,
+        func,
+        page_idx,
+        page_offset,
+        count,
+        little_endian
+    );
+
+    // slice #7: `(2, 7, vec![0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80])`
+    let (page_idx, page_offset, count) = (slices[7].0, slices[7].1, slices[7].2.len() as i32);
+
+    assert_int!(
+        0x10_20_30_40_50_60_70_80,
+        func,
+        page_idx,
+        page_offset,
+        count,
+        big_endian
+    );
+
+    assert_int!(
+        0x80_70_60_50_40_30_20_10,
+        func,
+        page_idx,
+        page_offset,
+        count,
+        little_endian
+    );
+}

--- a/crates/svm-runtime/tests/wasm/reg_pop.wast
+++ b/crates/svm-runtime/tests/wasm/reg_pop.wast
@@ -1,0 +1,11 @@
+(module
+  ;; import `SVM` vmcalls
+  (func $reg_pop (import "svm" "reg_pop") (param i32 i32))
+
+  (memory 1)  ;; memory `0` (default) is initialized with one page
+
+  ;; exported function to be called
+  (func (export "run") (param i32 i32)
+        get_local 0 ;; reg_bits
+        get_local 1 ;; reg_idx
+        call $reg_pop))

--- a/crates/svm-runtime/tests/wasm/reg_push.wast
+++ b/crates/svm-runtime/tests/wasm/reg_push.wast
@@ -1,0 +1,11 @@
+(module
+  ;; import `SVM` vmcalls
+  (func $reg_push (import "svm" "reg_push") (param i32 i32))
+
+  (memory 1)  ;; memory `0` (default) is initialized with one page
+
+  ;; exported function to be called
+  (func (export "run") (param i32 i32)
+        get_local 0 ;; reg_bits
+        get_local 1 ;; reg_idx
+        call $reg_push))

--- a/crates/svm-runtime/tests/wasm/storage_read_int.wast
+++ b/crates/svm-runtime/tests/wasm/storage_read_int.wast
@@ -1,0 +1,42 @@
+(module
+  ;; import `SVM` vmcalls
+  (func $storage_read_i32_be (import "svm" "storage_read_i32_be") (param i32 i32 i32) (result i32))
+  (func $storage_read_i32_le (import "svm" "storage_read_i32_le") (param i32 i32 i32) (result i32))
+  (func $storage_read_i64_be (import "svm" "storage_read_i64_be") (param i32 i32 i32) (result i64))
+  (func $storage_read_i64_le (import "svm" "storage_read_i64_le") (param i32 i32 i32) (result i64))
+
+  (memory 1)  ;; memory `0` (default) is initialized with one page
+
+  ;; exported function to be called
+  (func (export "read_i32") (param i32 i32 i32 i32) (result i32)
+        (if (result i32) (get_local 3)
+          (then
+            ;; Big-Endian
+           (get_local 0) ;; page_offset
+           (get_local 1) ;; page_idx
+           (get_local 2) ;; count
+           (call $storage_read_i32_be))
+          (else
+            ;; Little-Endian
+            (get_local 0) ;; page_offset
+            (get_local 1) ;; page_idx
+            (get_local 2) ;; count
+            (call $storage_read_i32_le))))
+
+
+  (func (export "read_i64") (param i32 i32 i32 i32) (result i64)
+        (if (result i64) (get_local 3)
+          (then
+            ;; Big-Endian
+           (get_local 0) ;; page_offset
+           (get_local 1) ;; page_idx
+           (get_local 2) ;; count
+           (call $storage_read_i64_be))
+          (else
+            ;; Little-Endian
+            (get_local 0) ;; page_offset
+            (get_local 1) ;; page_idx
+            (get_local 2) ;; count
+            (call $storage_read_i64_le)))))
+
+


### PR DESCRIPTION
## Motivation

When reading less than 8 bytes from app storage there we can return wasm integers primitives.

From [WebAssembly Semantics](https://github.com/WebAssembly/design/blob/376bcc4b9cba79280d79be023d71e30d0b00ba47/Semantics.md):
```
Note that the value types i32 and i64 are not inherently signed or unsigned. 
The interpretation of these types is determined by individual operators.
````
Therefore, our vmcalls will return `u32` and `u64`and not `i32 / i64` 