### PR TITLE
Adding `dry_run` flag mode.

### DIFF
--- a/crates/svm-runtime/src/traits.rs
+++ b/crates/svm-runtime/src/traits.rs
@@ -47,6 +47,7 @@ pub trait Runtime {
         app_tx: AppTransaction,
         state: State,
         host_ctx: HostCtx,
+        dry_run: bool,
     ) -> Result<Receipt, ExecAppError>;
 }
 

--- a/crates/svm-runtime/tests/runtime.rs
+++ b/crates/svm-runtime/tests/runtime.rs
@@ -112,8 +112,9 @@ fn runtime_exec_app() {
     let bytes = testing::build_app_tx(version, &app_addr, func_idx, &func_buf, &func_args);
 
     let tx = runtime.parse_exec_app(&sender, &bytes).unwrap();
+    let dry_run = false;
 
-    let res = runtime.exec_app(tx, init_state.clone(), HostCtx::new());
+    let res = runtime.exec_app(tx, init_state.clone(), HostCtx::new(), dry_run);
     let receipt = res.unwrap();
 
     assert_eq!(true, receipt.success);


### PR DESCRIPTION
The motivation for this PR is to add a `dry run` mode for a runtime.

Running in a dry mode is required when we want to simulate the execution of an app without modifying its state. A good use-case is when the Host would like to expose an app's data to the outside world.