### PR TITLE
Fixing copying `svm` header & objectfile

### DIFF
--- a/crates/svm-runtime-c-api/build.rs
+++ b/crates/svm-runtime-c-api/build.rs
@@ -3,9 +3,10 @@ use cbindgen::{Builder, Language};
 use std::{env, fs, path::PathBuf};
 
 fn main() {
-    gen_for_c();
+    generate_svm_header();
 }
-fn gen_for_c() {
+
+fn generate_svm_header() {
     let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
 
     let out_dir = env::var("OUT_DIR").unwrap();

--- a/crates/svm-runtime-c-api/build.rs
+++ b/crates/svm-runtime-c-api/build.rs
@@ -7,16 +7,11 @@ fn main() {
 }
 fn gen_for_c() {
     let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
-    let header_name = "svm";
 
-    // set expand dir for macro expanding
-    env::set_var("CARGO_EXPAND_TARGET_DIR", crate_dir.clone());
-
-    // set target ouput dir for header
     let out_dir = env::var("OUT_DIR").unwrap();
-    let mut out_header = PathBuf::from(&out_dir);
-    out_header.push(header_name);
-    out_header.set_extension("h");
+    let mut src_header = PathBuf::from(&out_dir);
+    src_header.push("svm");
+    src_header.set_extension("h");
 
     // build using cbindgen
     Builder::new()
@@ -26,15 +21,13 @@ fn gen_for_c() {
         .with_parse_expand(&["svm-runtime-c-api"])
         .generate()
         .expect("Unable to generate C bindings")
-        .write_to_file(out_header.as_path());
+        .write_to_file(src_header.as_path());
 
-    // `root project examples/c`
-    let out_path = PathBuf::from("../../examples/c");
-    let mut examples_header = PathBuf::from(&out_path);
-    examples_header.push(header_name);
-    examples_header.set_extension("h");
+    let mut dst_header = PathBuf::from("../../examples");
+    dst_header.push("svm");
+    dst_header.set_extension("h");
 
-    // copy the file from output to `examples`
-    fs::copy(out_header.as_path(), examples_header.as_path())
+    // copies `svm.h` under `examples`
+    fs::copy(src_header.as_path(), dst_header.as_path())
         .expect("Unable to copy the generated C bindings");
 }

--- a/examples/c/Makefile
+++ b/examples/c/Makefile
@@ -1,7 +1,7 @@
 CC = gcc
-OBJECTS = svm.dylib
+OBJECTS = ../svm.dylib
 CFLAGS = -g -Wall
-DEPS = counter.c svm.h
+DEPS = counter.c ../svm.h
 
 default: counter
 

--- a/examples/c/build.sh
+++ b/examples/c/build.sh
@@ -2,9 +2,11 @@
 set -e
 
 pushd ../../crates/svm-runtime-c-api
+# a build side-effect will to generate `svm.h` under `examples`.
 cargo +nightly build --release
 popd
 
+# figuring out the svm object file extension by platform
 unameOut="$(uname -s)"
 case "${unameOut}" in
   Linux*) ext=so;;
@@ -12,7 +14,8 @@ case "${unameOut}" in
   *) ext=invalid;;
 esac
 
-mv ../../crates/svm-runtime-c-api/target/release/libsvm_runtime_c_api.${ext} ./svm.${ext}
+# copying the `svm` objectfile under `examples`.
+mv ../../target/release/libsvm_runtime_c_api.${ext} ../svm.${ext}
 
 make counter
 

--- a/examples/c/counter.c
+++ b/examples/c/counter.c
@@ -3,7 +3,7 @@
 #include <string.h>
 #include <assert.h>
 
-#include "svm.h"
+#include "../svm.h"
 #include "constants.h"
 
 #include "wasm_file.h"

--- a/examples/c/deploy_bytes.h
+++ b/examples/c/deploy_bytes.h
@@ -6,7 +6,7 @@
 #include <string.h>
 #include <assert.h>
 
-#include "svm.h"
+#include "../svm.h"
 #include "wasm_file.h"
 
 svm_byte_array deploy_template_bytes() {

--- a/examples/c/exec_app_bytes.h
+++ b/examples/c/exec_app_bytes.h
@@ -4,7 +4,7 @@
 #include <assert.h>
 #include <stdlib.h>
 
-#include "svm.h"
+#include "../svm.h"
 #include "constants.h"
 #include "func_buf.h"
 #include "func_args.h"

--- a/examples/c/func_args.h
+++ b/examples/c/func_args.h
@@ -1,7 +1,7 @@
 #ifndef SVM_FUNC_ARGS_H
 #define SVM_FUNC_ARGS_H
 
-#include "svm.h"
+#include "../svm.h"
 
 typedef struct {
   svm_value_type type;

--- a/examples/c/func_buf.h
+++ b/examples/c/func_buf.h
@@ -2,7 +2,7 @@
 #define SVM_FUNC_BUF_H
 
 #include <stdint.h>
-#include "svm.h"
+#include "../svm.h"
 
 typedef struct {
   uint8_t slice_count;

--- a/examples/c/host_ctx.h
+++ b/examples/c/host_ctx.h
@@ -3,7 +3,7 @@
 
 #include <stdint.h>
 
-#include "svm.h"
+#include "../svm.h"
 
 svm_byte_array host_ctx_empty_bytes() {
   uint32_t length =

--- a/examples/c/receipt.h
+++ b/examples/c/receipt.h
@@ -3,7 +3,7 @@
 
 #include <stdint.h>
 
-#include "svm.h"
+#include "../svm.h"
 #include "constants.h"
 #include "func_rets.h"
 


### PR DESCRIPTION
## Motivation
Since the `examples` directory has been moved from within `svm-runtime-c-api/src/examples` to the project root dir, we have to fix the copy of `svm.h` file and and `build.sh` (which grabs the `svm` objectfile). 

It's a prerequisite to #79 