### PR TITLE
Refactor build scripts

### DIFF
--- a/crates/svm-runtime-c-api/build.rs
+++ b/crates/svm-runtime-c-api/build.rs
@@ -1,6 +1,6 @@
 extern crate cbindgen;
 use cbindgen::{Builder, Language};
-use std::{env, fs, path::PathBuf};
+use std::{env, path::PathBuf};
 
 fn main() {
     generate_svm_header();
@@ -8,11 +8,15 @@ fn main() {
 
 fn generate_svm_header() {
     let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
-
     let out_dir = env::var("OUT_DIR").unwrap();
+
+    // targeting the workspace 'target/release' dir
     let mut src_header = PathBuf::from(&out_dir);
-    src_header.push("svm");
-    src_header.set_extension("h");
+    src_header.pop();
+    src_header.pop();
+    src_header.pop();
+    src_header.pop();
+    src_header.push("release/svm.h");
 
     // build using cbindgen
     Builder::new()
@@ -23,12 +27,4 @@ fn generate_svm_header() {
         .generate()
         .expect("Unable to generate C bindings")
         .write_to_file(src_header.as_path());
-
-    let mut dst_header = PathBuf::from("../../examples");
-    dst_header.push("svm");
-    dst_header.set_extension("h");
-
-    // copies `svm.h` under `examples`
-    fs::copy(src_header.as_path(), dst_header.as_path())
-        .expect("Unable to copy the generated C bindings");
 }

--- a/crates/svm-runtime-c-api/build.rs
+++ b/crates/svm-runtime-c-api/build.rs
@@ -10,13 +10,13 @@ fn generate_svm_header() {
     let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
     let out_dir = env::var("OUT_DIR").unwrap();
 
-    // targeting the workspace 'target/release' dir
+    // targeting the workspace 'target/(debug|release) dir
     let mut src_header = PathBuf::from(&out_dir);
     src_header.pop();
     src_header.pop();
     src_header.pop();
-    src_header.pop();
-    src_header.push("release/svm.h");
+    src_header.push("svm");
+    src_header.set_extension("h");
 
     // build using cbindgen
     Builder::new()

--- a/examples/c/build.sh
+++ b/examples/c/build.sh
@@ -2,7 +2,7 @@
 set -e
 
 pushd ../../crates/svm-runtime-c-api
-# a build side-effect will to generate `svm.h` under `examples`.
+# a build side-effect will to generate `svm.h` under `target/release`.
 cargo +nightly build --release
 popd
 
@@ -14,8 +14,9 @@ case "${unameOut}" in
   *) ext=invalid;;
 esac
 
-# copying the `svm` objectfile under `examples`.
-mv ../../target/release/libsvm_runtime_c_api.${ext} ../svm.${ext}
+# copying the `svm` object/header files under `examples`.
+cp ../../target/release/libsvm_runtime_c_api.${ext} ../svm.${ext}
+cp ../../target/release/svm.h ../svm.h
 
 make counter
 


### PR DESCRIPTION
* Rust build script to output `svm.h` into `svm/target/release` instead of `svm/target/debug/build/svm-runtime-c-api-X/out`
* `build.sh` to copy objectfile instead of moving
* `build.sh` to copy `svm.h`, created by the Rust build script