### PR TITLE
Returning `error` via the c-api

### DIFF
--- a/crates/svm-app/src/rocksdb/app_store.rs
+++ b/crates/svm-app/src/rocksdb/app_store.rs
@@ -8,7 +8,7 @@ use crate::{
 
 /// `AppStore` implementation backed-by `rocksdb`
 pub struct RocksdbAppStore<S, D> {
-    _phantom: PhantomData<(S, D)>,
+    phantom: PhantomData<(S, D)>,
 }
 
 impl<S, D> RocksdbAppStore<S, D>
@@ -17,12 +17,12 @@ where
     D: AppDeserializer,
 {
     /// New `RocksdbAppStore` instance
-    pub fn new<P>(_path: &P) -> Self
+    pub fn new<P>(_path: P) -> Self
     where
         P: AsRef<Path>,
     {
         Self {
-            _phantom: PhantomData,
+            phantom: PhantomData,
         }
     }
 }

--- a/crates/svm-app/src/rocksdb/template_store.rs
+++ b/crates/svm-app/src/rocksdb/template_store.rs
@@ -22,7 +22,7 @@ where
     D: AppTemplateDeserializer,
 {
     /// Creates a new template store at the given path
-    pub fn new<P>(path: &P) -> Self
+    pub fn new<P>(path: P) -> Self
     where
         P: AsRef<Path>,
     {

--- a/crates/svm-kv/src/rocksdb/db.rs
+++ b/crates/svm-kv/src/rocksdb/db.rs
@@ -11,7 +11,7 @@ pub struct Rocksdb {
 impl Rocksdb {
     /// New `Rocksdb` under the given `path`
     pub fn new<P: AsRef<Path>>(path: P) -> Self {
-        info!("opening rocksdb. (path = \"{}\")", path.as_ref().display());
+        info!("Opening rocksdb. (path = \"{}\")", path.as_ref().display());
 
         Self {
             db: rocksdb::DB::open_default(path).unwrap(),
@@ -45,7 +45,7 @@ impl KVStore for Rocksdb {
         let res = self.db.write(batch);
 
         if res.is_err() {
-            panic!("failed `write`-ing bach");
+            panic!("failed storing changes.");
         }
     }
 }

--- a/crates/svm-runtime-c-api/src/error.rs
+++ b/crates/svm-runtime-c-api/src/error.rs
@@ -1,0 +1,29 @@
+use std::string::FromUtf8Error;
+
+use crate::svm_byte_array;
+use svm_app::error::ParseError;
+
+pub(crate) unsafe fn raw_parse_error(
+    parse_err: &ParseError,
+    error: *mut svm_byte_array
+} {
+    todo!()
+}
+
+pub(crate) unsafe fn raw_utf8_error<T>(
+    utf8_res: Result<T, FromUtf8Error>,
+    error: *mut svm_byte_array,
+) {
+    let utf8_err = utf8_res.err().unwrap();
+
+    raw_error(utf8_err.to_string(), error);
+}
+
+pub(crate) unsafe fn raw_error(s: String, error: *mut svm_byte_array) {
+    let s = Box::leak(Box::new(s));
+
+    let error = &mut *error;
+
+    error.bytes = s.as_ptr();
+    error.length = s.as_bytes().len() as u32;
+}

--- a/crates/svm-runtime-c-api/src/import.rs
+++ b/crates/svm-runtime-c-api/src/import.rs
@@ -11,6 +11,7 @@ pub enum svm_import_kind {
 
 /// FFI representation for import function signature
 #[allow(non_camel_case_types)]
+#[derive(Debug)]
 pub struct svm_import_func_sig_t {
     /// Function params types
     pub params: Vec<svm_value_type>,

--- a/crates/svm-runtime-c-api/src/lib.rs
+++ b/crates/svm-runtime-c-api/src/lib.rs
@@ -15,6 +15,7 @@ pub mod testing;
 mod address;
 mod api;
 mod byte_array;
+mod error;
 mod import;
 mod macros;
 mod receipt;
@@ -22,6 +23,8 @@ mod result;
 mod state;
 mod value;
 mod wasmer;
+
+pub(crate) use error::{raw_error, raw_utf8_error};
 
 /// `SVM` FFI Interface
 pub use api::{

--- a/crates/svm-runtime-c-api/src/testing/mod.rs
+++ b/crates/svm-runtime-c-api/src/testing/mod.rs
@@ -6,7 +6,7 @@ pub use receipt::{
     ClientExecReceipt, ClientTemplateReceipt,
 };
 
-use crate::svm_value_type;
+use crate::{svm_byte_array, svm_value_type};
 
 use svm_runtime::ctx::SvmCtx;
 
@@ -63,6 +63,8 @@ pub unsafe fn import_func_create(
     params: Vec<svm_value_type>,
     returns: Vec<svm_value_type>,
 ) {
+    let mut error = svm_byte_array::default();
+
     let res = crate::svm_import_func_build(
         imports,
         module_name.into(),
@@ -70,6 +72,8 @@ pub unsafe fn import_func_create(
         func,
         params.into(),
         returns.into(),
+        &mut error,
     );
+
     assert!(res.is_ok());
 }

--- a/crates/svm-runtime-c-api/tests/api_tests.rs
+++ b/crates/svm-runtime-c-api/tests/api_tests.rs
@@ -192,11 +192,14 @@ unsafe fn test_svm_runtime() {
     let mut runtime = std::ptr::null_mut();
     let imports = create_imports();
     let dry_run = false;
+    let mut error = svm_byte_array::default();
 
     let res = api::svm_memory_kv_create(&mut kv);
     assert!(res.is_ok());
 
-    let res = api::svm_memory_runtime_create(&mut runtime, kv, host.as_mut_ptr(), imports);
+    let res =
+        api::svm_memory_runtime_create(&mut runtime, kv, host.as_mut_ptr(), imports, &mut error);
+
     assert!(res.is_ok());
 
     // 2) deploy app-template
@@ -226,6 +229,7 @@ unsafe fn test_svm_runtime() {
         author,
         host_ctx,
         dry_run,
+        &mut error,
     );
     assert!(res.is_ok());
 
@@ -262,6 +266,7 @@ unsafe fn test_svm_runtime() {
         creator,
         host_ctx,
         dry_run,
+        &mut error,
     );
     assert!(res.is_ok());
 
@@ -309,6 +314,7 @@ unsafe fn test_svm_runtime() {
         init_state,
         host_ctx,
         dry_run,
+        &mut error,
     );
     assert!(res.is_ok());
 

--- a/crates/svm-runtime-c-api/tests/wasm/update-balance.wast
+++ b/crates/svm-runtime-c-api/tests/wasm/update-balance.wast
@@ -5,7 +5,7 @@
   (func $host_ctx_read_i64_le (import "svm" "host_ctx_read_i64_le") (param i32) (result i64))
   (func $buffer_copy_to_reg (import "svm" "buffer_copy_to_reg") (param i32 i32 i32 i32 i32))
 
-  ;; host vmcalls
+  ;; Host vmcalls
   (func $inc_balance (import "env" "inc_balance") (param i64 i32 i32))
   (func $mul_balance (import "env" "mul_balance") (param i64 i32 i32))
 

--- a/crates/svm-runtime/src/settings.rs
+++ b/crates/svm-runtime/src/settings.rs
@@ -1,6 +1,11 @@
+use std::path::PathBuf;
+
 /// Holds settings for using the Runtime.
 #[derive(Debug, Clone)]
 pub struct AppSettings {
-    /// number of pages required by the app storage
+    /// #pages required by the app storage
     pub page_count: u16,
+
+    /// The path for the kv store
+    pub kv_path: PathBuf,
 }

--- a/crates/svm-runtime/src/testing.rs
+++ b/crates/svm-runtime/src/testing.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, collections::HashMap, ffi::c_void, rc::Rc};
+use std::{cell::RefCell, collections::HashMap, ffi::c_void, path::Path, rc::Rc};
 
 use crate::{
     buffer::BufferRef,
@@ -108,8 +108,9 @@ pub fn create_memory_runtime(
     let storage_builder = runtime_memory_storage_builder(kv);
 
     let env = runtime_memory_env_builder();
+    let kv_path = Path::new("mem");
 
-    DefaultRuntime::new(host, env, imports, Box::new(storage_builder))
+    DefaultRuntime::new(host, env, &kv_path, imports, Box::new(storage_builder))
 }
 
 /// Creates an app storage builder function backed by key-value store `kv`.

--- a/crates/svm-runtime/tests/runtime.rs
+++ b/crates/svm-runtime/tests/runtime.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use svm_app::types::{HostCtx, WasmValue};
 use svm_common::Address;
 use svm_runtime::{runtime::Runtime, settings::AppSettings, testing};
@@ -38,7 +40,10 @@ fn runtime_spawn_app_with_ctor() {
 
     let receipt = runtime.spawn_app(&bytes, &creator, HostCtx::new(), false);
 
-    let settings = AppSettings { page_count };
+    let settings = AppSettings {
+        page_count,
+        kv_path: Path::new("mem").to_path_buf(),
+    };
 
     let mut storage =
         runtime.open_app_storage(receipt.get_app_addr(), receipt.get_init_state(), &settings);
@@ -124,7 +129,10 @@ fn runtime_exec_app() {
     // now we'll read directly from the app's storage
     // and assert that the data has been persisted as expected.
 
-    let settings = AppSettings { page_count };
+    let settings = AppSettings {
+        page_count,
+        kv_path: Path::new("mem").to_path_buf(),
+    };
     let mut storage = runtime.open_app_storage(app_addr, receipt.get_new_state(), &settings);
 
     let layout = PageSliceLayout::new(


### PR DESCRIPTION
# Motivation 
The current C-API returns `svm_result_t`, we'd like to return also the reason (as `svm_byte_array`)
for the errors.