### PR TITLE
Introducing `namespace` to the kv-store API.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -634,9 +634,9 @@ checksum = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 
 [[package]]
 name = "regex"
-version = "1.3.5"
+version = "1.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8900ebc1363efa7ea1c399ccc32daed870b4002651e0bed86e72d501ebbe0048"
+checksum = "7f6946991529684867e47d86474e3a6d0c0ab9b82d5821e314b1ede31fa3a4b3"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -805,10 +805,10 @@ name = "svm"
 version = "0.0.0"
 dependencies = [
  "byteorder",
+ "lazy_static",
  "libc",
  "log",
  "rocksdb",
- "serde",
  "svm-app",
  "svm-common",
  "svm-compiler",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -831,6 +831,7 @@ version = "0.0.0"
 dependencies = [
  "bit-vec",
  "byteorder",
+ "lazy_static",
  "log",
  "maplit",
  "svm-common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -936,6 +936,7 @@ version = "0.0.0"
 dependencies = [
  "cfg-if",
  "hash256-std-hasher",
+ "lazy_static",
  "log",
  "svm-common",
  "svm-kv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ libc = "0.2"
 byteorder = "1.3.2"
 tiny-keccak = "1.4.2"
 log = "0.4"
-serde = { version = "1.0.98", features = ["derive"] }
+lazy_static = "1.4.0"
 svm-common = { path = "crates/svm-common" }
 svm-kv = { path = "crates/svm-kv" }
 svm-gas = { path = "crates/svm-gas" }

--- a/crates/svm-app/Cargo.toml
+++ b/crates/svm-app/Cargo.toml
@@ -21,6 +21,9 @@ version = "0.4"
 [dependencies.bit-vec]
 version = "0.6.1"
 
+[dependencies.lazy_static]
+version = "1.4.0"
+
 [features]
 default = ["memory", "default-rocksdb"]
 memory = ["svm-kv/memory"]

--- a/crates/svm-kv/src/key.rs
+++ b/crates/svm-kv/src/key.rs
@@ -1,5 +1,12 @@
 #[allow(unused)]
-pub(crate) fn concat_ns_to_key(ns: &[u8], key: &[u8]) -> Vec<u8> {
+pub(crate) fn concat_ns_to_key<NS, K>(ns: NS, key: K) -> Vec<u8>
+where
+    NS: AsRef<[u8]>,
+    K: AsRef<[u8]>,
+{
+    let ns = ns.as_ref();
+    let key = key.as_ref();
+
     let cap = if ns.len() > 0 {
         ns.len() + 1 + key.len()
     } else {

--- a/crates/svm-kv/src/key.rs
+++ b/crates/svm-kv/src/key.rs
@@ -1,0 +1,45 @@
+#[allow(unused)]
+pub(crate) fn concat_ns_to_key(ns: &[u8], key: &[u8]) -> Vec<u8> {
+    let cap = if ns.len() > 0 {
+        ns.len() + 1 + key.len()
+    } else {
+        key.len()
+    };
+
+    let mut buf = Vec::with_capacity(cap);
+
+    if ns.len() > 0 {
+        buf.extend_from_slice(ns);
+        buf.extend_from_slice(&[b':']);
+    }
+
+    buf.extend_from_slice(key);
+    buf
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn concat_ns_to_key_empty_ns() {
+        let ns = vec![];
+        let key = vec![b'a', b'b', b'c'];
+
+        let actual = concat_ns_to_key(&ns, &key);
+        let expected = "abc".as_bytes();
+
+        assert_eq!(&expected[..], &actual[..]);
+    }
+
+    #[test]
+    fn concat_ns_to_key_non_empty_ns() {
+        let ns = vec![b'n', b's'];
+        let key = vec![b'a', b'b', b'c'];
+
+        let actual = concat_ns_to_key(&ns, &key);
+        let expected = "ns:abc".as_bytes();
+
+        assert_eq!(&expected[..], &actual[..]);
+    }
+}

--- a/crates/svm-kv/src/key.rs
+++ b/crates/svm-kv/src/key.rs
@@ -1,5 +1,6 @@
+/// Concatenates a namespace and a key into a fully-qualified key.
 #[allow(unused)]
-pub(crate) fn concat_ns_to_key<NS, K>(ns: NS, key: K) -> Vec<u8>
+pub fn concat_ns_to_key<NS, K>(ns: NS, key: K) -> Vec<u8>
 where
     NS: AsRef<[u8]>,
     K: AsRef<[u8]>,

--- a/crates/svm-kv/src/lib.rs
+++ b/crates/svm-kv/src/lib.rs
@@ -3,11 +3,13 @@
 #![deny(dead_code)]
 #![deny(unreachable_code)]
 
-//! The `svm-kv` is responsible on providing different implementations for the `KVStore` trait.
-//! (defined in `traits.rs`).
+//! The `svm-kv` crate is responsible on providing different implementations for the `KVStore` trait.
 
 /// Defines the `KVStore` trait.
 pub mod traits;
+
+/// Helpers for composing keys.
+pub mod key;
 
 /// An in-memory implementation for `KVStore`
 #[cfg(feature = "memory")]

--- a/crates/svm-kv/src/memory.rs
+++ b/crates/svm-kv/src/memory.rs
@@ -1,4 +1,5 @@
-use crate::traits::KVStore;
+use crate::{key::concat_ns_to_key, traits::KVStore};
+
 use std::collections::{hash_map, HashMap};
 
 use log::{debug, info};
@@ -38,8 +39,10 @@ impl MemKVStore {
 }
 
 impl KVStore for MemKVStore {
-    fn get(&self, key: &[u8]) -> Option<Vec<u8>> {
-        let entry = self.map.get(key);
+    fn get(&self, ns: &[u8], key: &[u8]) -> Option<Vec<u8>> {
+        let key = concat_ns_to_key(ns, key);
+
+        let entry = self.map.get(&key);
 
         if let Some(entry) = entry {
             Some(entry.clone())
@@ -48,17 +51,19 @@ impl KVStore for MemKVStore {
         }
     }
 
-    fn store(&mut self, changes: &[(&[u8], &[u8])]) {
-        info!("storing in-memory kv changeset");
+    fn store(&mut self, ns: &[u8], changes: &[(&[u8], &[u8])]) {
+        info!("Storing in-memory kv changeset");
 
         for (k, v) in changes {
-            self.map.insert(k.to_vec(), v.to_vec());
+            let k = concat_ns_to_key(ns, k);
+
+            self.map.insert(k, v.to_vec());
         }
     }
 }
 
 impl Drop for MemKVStore {
     fn drop(&mut self) {
-        debug!("dropping `MemKVStore`...")
+        debug!("Dropping `MemKVStore`...")
     }
 }

--- a/crates/svm-kv/src/memory.rs
+++ b/crates/svm-kv/src/memory.rs
@@ -51,13 +51,14 @@ impl KVStore for MemKVStore {
         }
     }
 
-    fn store(&mut self, ns: &[u8], changes: &[(&[u8], &[u8])]) {
+    fn store(&mut self, changes: &[(&[u8], &[u8], &[u8])]) {
         info!("Storing in-memory kv changeset");
 
-        for (k, v) in changes {
+        for (ns, k, v) in changes {
             let k = concat_ns_to_key(ns, k);
+            let v = v.as_ref().to_vec();
 
-            self.map.insert(k, v.to_vec());
+            self.map.insert(k, v);
         }
     }
 }

--- a/crates/svm-kv/src/memory.rs
+++ b/crates/svm-kv/src/memory.rs
@@ -43,12 +43,7 @@ impl KVStore for MemKVStore {
         let key = concat_ns_to_key(ns, key);
 
         let entry = self.map.get(&key);
-
-        if let Some(entry) = entry {
-            Some(entry.clone())
-        } else {
-            None
-        }
+        entry.cloned()
     }
 
     fn store(&mut self, changes: &[(&[u8], &[u8], &[u8])]) {

--- a/crates/svm-kv/src/rocksdb/db.rs
+++ b/crates/svm-kv/src/rocksdb/db.rs
@@ -1,5 +1,6 @@
-use crate::traits::KVStore;
 use std::path::Path;
+
+use crate::{key::concat_ns_to_key, traits::KVStore};
 
 use log::info;
 
@@ -21,8 +22,10 @@ impl Rocksdb {
 
 impl KVStore for Rocksdb {
     #[allow(clippy::match_wild_err_arm)]
-    fn get(&self, key: &[u8]) -> Option<Vec<u8>> {
-        match self.db.get(key) {
+    fn get(&self, ns: &[u8], key: &[u8]) -> Option<Vec<u8>> {
+        let key = concat_ns_to_key(ns, key);
+
+        match self.db.get(&key) {
             Ok(dbvec) => match dbvec {
                 None => None,
                 Some(dbvec) => Some(dbvec.to_vec()),
@@ -31,10 +34,12 @@ impl KVStore for Rocksdb {
         }
     }
 
-    fn store(&mut self, changes: &[(&[u8], &[u8])]) {
+    fn store(&mut self, ns: &[u8], changes: &[(&[u8], &[u8])]) {
         let mut batch = rocksdb::WriteBatch::default();
 
         for (k, v) in changes {
+            let k = concat_ns_to_key(ns, k);
+
             let res = batch.put(k, v);
 
             if res.is_err() {
@@ -64,15 +69,17 @@ mod tests {
     fn rocksdb_sanity() {
         let mut db = Rocksdb::new("rocksdb-tests");
 
-        db.store(&[(&[10, 20, 30], &[40, 50, 60])]);
+        let ns = vec![0xFF, 0xFF];
 
-        let v = db.get(&[10, 20, 30]).unwrap();
+        db.store(&ns, &[(&[10, 20, 30], &[40, 50, 60])]);
+
+        let v = db.get(&ns, &[10, 20, 30]).unwrap();
         assert_eq!(vec![40, 50, 60], v);
 
         drop(db);
 
         let db = Rocksdb::new("rocksdb-tests");
-        let v = db.get(&[10, 20, 30]).unwrap();
+        let v = db.get(&ns, &[10, 20, 30]).unwrap();
         assert_eq!(vec![40, 50, 60], v);
     }
 }

--- a/crates/svm-kv/src/traits.rs
+++ b/crates/svm-kv/src/traits.rs
@@ -1,9 +1,9 @@
-/// `KVStore` is a trait for defining an interface against key-value stores. for example `in-memory / rocksdb`
+/// `KVStore` is a trait for defining an interface against key-value stores. for example `rocksdb/leveldb`.
 pub trait KVStore {
     /// Retrieves the value pointed by `key` (Optional).
     #[must_use]
-    fn get(&self, key: &[u8]) -> Option<Vec<u8>>;
+    fn get(&self, ns: &[u8], key: &[u8]) -> Option<Vec<u8>>;
 
     /// Stores a batch of changes. Each change is `key` -> `value` association.
-    fn store(&mut self, changes: &[(&[u8], &[u8])]);
+    fn store(&mut self, ns: &[u8], changes: &[(&[u8], &[u8])]);
 }

--- a/crates/svm-kv/src/traits.rs
+++ b/crates/svm-kv/src/traits.rs
@@ -1,9 +1,9 @@
-/// `KVStore` is a trait for defining an interface against key-value stores. for example `rocksdb/leveldb`.
+/// `KVStore` is a trait for defining an interface against key-value stores, for example `rocksdb/leveldb`.
 pub trait KVStore {
     /// Retrieves the value pointed by `key` (Optional).
     #[must_use]
     fn get(&self, ns: &[u8], key: &[u8]) -> Option<Vec<u8>>;
 
-    /// Stores a batch of changes. Each change is `key` -> `value` association.
-    fn store(&mut self, ns: &[u8], changes: &[(&[u8], &[u8])]);
+    /// Stores a batch of changes. Each change is `(ns, key) -> value` association.
+    fn store(&mut self, changes: &[(&[u8], &[u8], &[u8])]);
 }

--- a/crates/svm-kv/tests/asserts.rs
+++ b/crates/svm-kv/tests/asserts.rs
@@ -1,21 +1,21 @@
 #[macro_export]
 macro_rules! assert_key_value {
-    ($kv: expr, $key: expr, $expected: expr) => {{
-        let actual = $kv.get(&$key).unwrap();
+    ($kv:expr, $ns:expr, $key:expr, $expected:expr) => {{
+        let actual = $kv.get(&$ns, &$key).unwrap();
         assert_eq!($expected, &actual[..]);
     }};
 }
 
 #[macro_export]
 macro_rules! assert_no_key {
-    ($kv: expr, $key: expr) => {{
-        assert!($kv.get(&$key).is_none());
+    ($kv:expr, $ns:expr, $key:expr) => {{
+        assert!($kv.get(&$ns, &$key).is_none());
     }};
 }
 
 #[macro_export]
 macro_rules! kv_keys_vec {
-    ($kv: ident) => {{
+    ($kv:ident) => {{
         let keys: Vec<Vec<u8>> = $kv.borrow().keys().map(|key| key.clone()).collect();
         keys
     }};
@@ -23,7 +23,7 @@ macro_rules! kv_keys_vec {
 
 #[macro_export]
 macro_rules! assert_same_keys {
-    ($expected: expr, $actual: expr) => {{
+    ($expected:expr, $actual:expr) => {{
         let mut expected = $expected
             .iter()
             .map(|k| k.to_vec())

--- a/crates/svm-kv/tests/memory_kv_tests.rs
+++ b/crates/svm-kv/tests/memory_kv_tests.rs
@@ -8,13 +8,14 @@ fn init() {
 }
 
 #[test]
-fn a_key_does_not_exit_by_default() {
+fn key_store_keys_do_not_exit_by_default() {
     init();
 
     let kv = MemKVStore::new();
     let addr = Address::of("@someone");
+    let ns = vec![0xFF, 0xFF];
 
-    assert_no_key!(kv, addr.as_slice());
+    assert_no_key!(kv, ns, addr.as_slice());
 }
 
 #[test]
@@ -23,9 +24,11 @@ fn key_store_and_then_key_get() {
 
     let mut kv = MemKVStore::new();
     let addr = Address::of("someone");
-    kv.store(&[(addr.as_slice(), &[10, 20, 30])]);
+    let ns = vec![0xFF, 0xFF];
 
-    assert_key_value!(kv, addr.as_slice(), vec![10, 20, 30]);
+    kv.store(&ns, &[(addr.as_slice(), &[10, 20, 30])]);
+
+    assert_key_value!(kv, ns, addr.as_slice(), vec![10, 20, 30]);
 }
 
 #[test]
@@ -34,12 +37,13 @@ fn key_store_override_existing_entry() {
 
     let mut kv = MemKVStore::new();
     let addr = Address::of("someone");
+    let ns = vec![0xFF, 0xFF];
 
-    kv.store(&[(addr.as_slice(), &[10, 20, 30])]);
-    assert_key_value!(kv, addr.as_slice(), vec![10, 20, 30]);
+    kv.store(&ns, &[(addr.as_slice(), &[10, 20, 30])]);
+    assert_key_value!(kv, ns, addr.as_slice(), vec![10, 20, 30]);
 
-    kv.store(&[(addr.as_slice(), &[40, 50, 60])]);
-    assert_key_value!(kv, addr.as_slice(), vec![40, 50, 60]);
+    kv.store(&ns, &[(addr.as_slice(), &[40, 50, 60])]);
+    assert_key_value!(kv, ns, addr.as_slice(), vec![40, 50, 60]);
 }
 
 #[test]
@@ -49,17 +53,21 @@ fn clear() {
     let mut kv = MemKVStore::new();
     let addr1 = Address::of("Alice");
     let addr2 = Address::of("Bob");
+    let ns = vec![0xFF, 0xFF];
 
-    kv.store(&[
-        (addr1.as_slice(), &[10, 20, 30]),
-        (addr2.as_slice(), &[40, 50, 60]),
-    ]);
+    kv.store(
+        &ns,
+        &[
+            (addr1.as_slice(), &[10, 20, 30]),
+            (addr2.as_slice(), &[40, 50, 60]),
+        ],
+    );
 
-    assert_key_value!(kv, addr1.as_slice(), vec![10, 20, 30]);
-    assert_key_value!(kv, addr2.as_slice(), vec![40, 50, 60]);
+    assert_key_value!(kv, ns, addr1.as_slice(), vec![10, 20, 30]);
+    assert_key_value!(kv, ns, addr2.as_slice(), vec![40, 50, 60]);
 
     kv.clear();
 
-    assert_no_key!(kv, addr1.as_slice());
-    assert_no_key!(kv, addr2.as_slice());
+    assert_no_key!(kv, ns, addr1.as_slice());
+    assert_no_key!(kv, ns, addr2.as_slice());
 }

--- a/crates/svm-kv/tests/memory_kv_tests.rs
+++ b/crates/svm-kv/tests/memory_kv_tests.rs
@@ -11,24 +11,30 @@ fn init() {
 fn key_store_keys_do_not_exit_by_default() {
     init();
 
-    let kv = MemKVStore::new();
     let addr = Address::of("@someone");
-    let ns = vec![0xFF, 0xFF];
 
-    assert_no_key!(kv, ns, addr.as_slice());
+    let kv: MemKVStore = MemKVStore::new();
+    let ns = vec![0xFF, 0xFF];
+    let key = addr.as_slice();
+
+    assert_no_key!(kv, ns, key);
 }
 
 #[test]
 fn key_store_and_then_key_get() {
     init();
 
-    let mut kv = MemKVStore::new();
     let addr = Address::of("someone");
+
+    let mut kv = MemKVStore::new();
     let ns = vec![0xFF, 0xFF];
+    let key = addr.as_slice();
+    let val = vec![10, 20, 30];
 
-    kv.store(&ns, &[(addr.as_slice(), &[10, 20, 30])]);
+    let change = (&ns[..], &key[..], &val[..]);
+    kv.store(&[change]);
 
-    assert_key_value!(kv, ns, addr.as_slice(), vec![10, 20, 30]);
+    assert_key_value!(kv, ns, key, val);
 }
 
 #[test]
@@ -37,13 +43,19 @@ fn key_store_override_existing_entry() {
 
     let mut kv = MemKVStore::new();
     let addr = Address::of("someone");
+
     let ns = vec![0xFF, 0xFF];
+    let key = addr.as_slice();
+    let val1 = vec![10, 20, 30];
+    let val2 = vec![40, 50, 60];
 
-    kv.store(&ns, &[(addr.as_slice(), &[10, 20, 30])]);
-    assert_key_value!(kv, ns, addr.as_slice(), vec![10, 20, 30]);
+    let change = (&ns[..], &key[..], &val1[..]);
+    kv.store(&[change]);
+    assert_key_value!(kv, ns, key, val1);
 
-    kv.store(&ns, &[(addr.as_slice(), &[40, 50, 60])]);
-    assert_key_value!(kv, ns, addr.as_slice(), vec![40, 50, 60]);
+    let change = (&ns[..], &key[..], &val2[..]);
+    kv.store(&[change]);
+    assert_key_value!(kv, ns, key, val2);
 }
 
 #[test]
@@ -53,21 +65,26 @@ fn clear() {
     let mut kv = MemKVStore::new();
     let addr1 = Address::of("Alice");
     let addr2 = Address::of("Bob");
+
+    let key1 = addr1.as_slice();
+    let key2 = addr2.as_slice();
+
+    let val1 = vec![10, 20, 30];
+    let val2 = vec![40, 50, 60];
     let ns = vec![0xFF, 0xFF];
 
-    kv.store(
-        &ns,
-        &[
-            (addr1.as_slice(), &[10, 20, 30]),
-            (addr2.as_slice(), &[40, 50, 60]),
-        ],
-    );
+    let changes = [
+        (&ns[..], &key1[..], &val1[..]),
+        (&ns[..], &key2[..], &val2[..]),
+    ];
 
-    assert_key_value!(kv, ns, addr1.as_slice(), vec![10, 20, 30]);
-    assert_key_value!(kv, ns, addr2.as_slice(), vec![40, 50, 60]);
+    kv.store(&changes);
+
+    assert_key_value!(kv, ns, key1, val1);
+    assert_key_value!(kv, ns, key2, val2);
 
     kv.clear();
 
-    assert_no_key!(kv, ns, addr1.as_slice());
-    assert_no_key!(kv, ns, addr2.as_slice());
+    assert_no_key!(kv, ns, key1);
+    assert_no_key!(kv, ns, key2);
 }

--- a/crates/svm-runtime-c-api/src/receipt/exec_app.rs
+++ b/crates/svm-runtime-c-api/src/receipt/exec_app.rs
@@ -81,7 +81,7 @@ mod tests {
 
     #[test]
     fn encode_decode_exec_receipt_success_without_returns() {
-        let new_state = State::from(0x10_20_30_40);
+        let new_state = State::of("some-state");
 
         let expected = ClientExecReceipt::Success {
             new_state: new_state.clone(),
@@ -104,7 +104,7 @@ mod tests {
 
     #[test]
     fn encode_decode_exec_receipt_success_with_returns() {
-        let new_state = State::from(0x10_20_30_40);
+        let new_state = State::of("some-state");
         let returns = vec![WasmValue::I32(10), WasmValue::I64(20), WasmValue::I32(30)];
 
         let expected = ClientExecReceipt::Success {

--- a/crates/svm-runtime-c-api/src/receipt/spawn_app.rs
+++ b/crates/svm-runtime-c-api/src/receipt/spawn_app.rs
@@ -93,7 +93,7 @@ mod tests {
     #[test]
     fn encode_decode_app_receipt_success_without_returns() {
         let addr: AppAddr = Address::of("my-app").into();
-        let init_state = State::from(0x10_20_30_40);
+        let init_state = State::of("some-state");
 
         let expected = ClientAppReceipt::Success {
             addr: addr.clone(),
@@ -119,7 +119,7 @@ mod tests {
     #[test]
     fn encode_decode_app_receipt_success_with_returns() {
         let addr: AppAddr = Address::of("my-app").into();
-        let init_state = State::from(0x10_20_30_40);
+        let init_state = State::of("some-state");
         let returns = vec![WasmValue::I32(10), WasmValue::I64(20), WasmValue::I32(30)];
 
         let expected = ClientAppReceipt::Success {

--- a/crates/svm-runtime/src/runtime/rocksdb.rs
+++ b/crates/svm-runtime/src/runtime/rocksdb.rs
@@ -50,12 +50,12 @@ where
     RocksdbEnv::new(app_store, template_store)
 }
 
-fn app_storage_build(addr: &AppAddr, state: &State, settings: &AppSettings) -> AppStorage {
+fn app_storage_build(_addr: &AppAddr, state: &State, settings: &AppSettings) -> AppStorage {
     let path = Path::new(&settings.kv_path);
 
     let kv = Rc::new(RefCell::new(Rocksdb::new(path)));
 
-    let pages = RocksdbAppPages::new(addr.inner().clone(), kv, state.clone(), settings.page_count);
+    let pages = RocksdbAppPages::new(kv, state.clone(), settings.page_count);
     let cache = RocksdbAppPageCache::new(pages, settings.page_count);
 
     AppStorage::new(Box::new(cache))

--- a/crates/svm-runtime/src/testing.rs
+++ b/crates/svm-runtime/src/testing.rs
@@ -75,7 +75,7 @@ pub fn instance_memory_init(instance: &Instance, offset: u32, bytes: &[u8]) {
 
 /// Returns a `state creator` to be used by wasmer `ImportObject::new_with_data` initializer.
 pub fn app_memory_state_creator(
-    app_addr: &Address,
+    _app_addr: &Address,
     state: &State,
     host: DataWrapper<*mut c_void>,
     host_ctx: DataWrapper<*const c_void>,
@@ -83,7 +83,7 @@ pub fn app_memory_state_creator(
 ) -> (*mut c_void, fn(*mut c_void)) {
     let kv = memory_kv_store_init();
 
-    let storage = svm_storage::testing::app_storage_open(app_addr, state, &kv, page_count);
+    let storage = svm_storage::testing::app_storage_open(state, &kv, page_count);
 
     let ctx = SvmCtx::new(host, host_ctx, storage);
     let ctx: *mut SvmCtx = Box::into_raw(Box::new(ctx));
@@ -117,8 +117,8 @@ pub fn create_memory_runtime(
 pub fn runtime_memory_storage_builder(kv: &Rc<RefCell<MemKVStore>>) -> Box<StorageBuilderFn> {
     let kv = Rc::clone(kv);
 
-    let func = move |addr: &AppAddr, state: &State, settings: &AppSettings| {
-        svm_storage::testing::app_storage_open(addr.inner(), state, &kv, settings.page_count)
+    let func = move |_addr: &AppAddr, state: &State, settings: &AppSettings| {
+        svm_storage::testing::app_storage_open(state, &kv, settings.page_count)
     };
 
     Box::new(func)

--- a/crates/svm-storage/Cargo.toml
+++ b/crates/svm-storage/Cargo.toml
@@ -13,6 +13,7 @@ publish = false
 [dependencies]
 cfg-if = "0.1.9"
 log = "0.4"
+lazy_static = "1.4.0"
 
 [dependencies.svm-common]
 path = "../svm-common"

--- a/crates/svm-storage/src/app_pages.rs
+++ b/crates/svm-storage/src/app_pages.rs
@@ -12,8 +12,11 @@ use lazy_static::lazy_static;
 use log::{debug, trace};
 
 lazy_static! {
-    static ref PAGE_NS: Vec<u8> = vec![b'p'];
-    static ref STATE_NS: Vec<u8> = vec![b's'];
+    /// `Page` namespace for kv-store.
+    pub static ref PAGE_NS: Vec<u8> = vec![b'p'];
+
+    /// `State` namespace for kv-store.
+    pub static ref STATE_NS: Vec<u8> = vec![b's'];
 }
 
 #[derive(Debug, Clone)]
@@ -247,10 +250,10 @@ where
 
         let changeset = self.prepare_changeset();
 
-        let mut entries: Vec<(&[u8], &[u8])> = Vec::with_capacity(1 + changeset.changes.len());
+        let mut entries = Vec::with_capacity(1 + changeset.changes.len());
 
         let state_entry = (
-            &STATE_NS,
+            &STATE_NS[..],
             changeset.state.as_slice(),
             changeset.jph.as_slice(),
         );
@@ -260,7 +263,7 @@ where
             let k = change.new_hash.as_ref();
             let v = &change.new_data[..];
 
-            let entry = (&PAGE_NS, k, v);
+            let entry = (&PAGE_NS[..], k, v);
             entries.push(entry);
         }
 

--- a/crates/svm-storage/src/default/page_hasher.rs
+++ b/crates/svm-storage/src/default/page_hasher.rs
@@ -18,8 +18,6 @@ impl PageHasher for DefaultPageHasher {
 mod tests {
     use super::*;
 
-    use crate::page::PageIndex;
-
     #[test]
     fn default_page_hasher_sanity() {
         let page_data = vec![10, 20, 30];

--- a/crates/svm-storage/src/default/state_hasher.rs
+++ b/crates/svm-storage/src/default/state_hasher.rs
@@ -1,10 +1,8 @@
-use crate::{
-    page::{JoinedPagesHash, PageHash, PAGE_HASH_LEN},
-    traits::StateHasher,
-};
+use crate::{page::JoinedPagesHash, traits::StateHasher};
 
 use svm_common::{DefaultKeyHasher, KeyHasher, State};
 
+/// Default `StateHasher` implementation.
 pub struct DefaultStateHasher;
 
 impl StateHasher for DefaultStateHasher {
@@ -23,11 +21,7 @@ impl StateHasher for DefaultStateHasher {
 mod tests {
     use super::*;
 
-    use crate::{
-        default::DefaultPageHasher,
-        page::{JoinedPagesHash, PageIndex},
-        traits::PageHasher,
-    };
+    use crate::{default::DefaultPageHasher, page::JoinedPagesHash, traits::PageHasher};
 
     use svm_common::{DefaultKeyHasher, KeyHasher};
 
@@ -39,7 +33,7 @@ mod tests {
         let hash1 = DefaultPageHasher::hash(&page1);
         let hash2 = DefaultPageHasher::hash(&page2);
 
-        let mut jph = JoinedPagesHash::new(vec![hash1.clone(), hash2.clone()]);
+        let jph = JoinedPagesHash::new(vec![hash1.clone(), hash2.clone()]);
         let bytes = DefaultKeyHasher::hash(jph.as_slice());
         let expected = State::from(&bytes[..]);
 

--- a/crates/svm-storage/src/lib.rs
+++ b/crates/svm-storage/src/lib.rs
@@ -1,7 +1,7 @@
-#![allow(missing_docs)]
-#![allow(unused)]
-#![allow(dead_code)]
-#![allow(unreachable_code)]
+#![deny(missing_docs)]
+#![deny(unused)]
+#![deny(dead_code)]
+#![deny(unreachable_code)]
 
 //! `svm-storage` crate is responsible for the app-storage part of the `SVM`
 //! Each app has its own storage

--- a/crates/svm-storage/src/page/joined_pages_hash.rs
+++ b/crates/svm-storage/src/page/joined_pages_hash.rs
@@ -1,21 +1,26 @@
 use super::{PageHash, PageIndex};
 
+/// Concatenates a vector of `PageHash`.
+/// Since we need to use thee result in a few places, we have `JoinedPagesHash` as a cache.
 pub struct JoinedPagesHash {
     bytes: Vec<u8>,
     pages_hash: Vec<PageHash>,
 }
 
 impl JoinedPagesHash {
+    /// Creates a new instnace
     pub fn new(pages_hash: Vec<PageHash>) -> Self {
         let bytes = pages_hash.iter().flat_map(|ph| ph.0.to_vec()).collect();
 
         Self { pages_hash, bytes }
     }
 
+    /// Returns the concatenated pages-hash as a slice.
     pub fn as_slice(&self) -> &[u8] {
         &self.bytes[..]
     }
 
+    /// Returns the `PageHash` of page `page_idx`.
     pub fn get_page_hash(&self, page_idx: PageIndex) -> &PageHash {
         let idx = page_idx.0 as usize;
 

--- a/crates/svm-storage/src/testing/app_page_cache.rs
+++ b/crates/svm-storage/src/testing/app_page_cache.rs
@@ -1,35 +1,28 @@
-use std::cell::RefCell;
-use std::rc::Rc;
+use std::{cell::RefCell, rc::Rc};
 
-use svm_common::{Address, State};
+use svm_common::State;
 use svm_kv::memory::MemKVStore;
 
 use crate::{default::DefaultPageCache, memory::MemAppPages, testing};
 
 /// Initialises a new page-cache backed by a new initialized in-memory pages-storage.
 pub fn app_page_cache_init(
-    addr: &str,
     page_count: u16,
-) -> (
-    Address,
-    Rc<RefCell<MemKVStore>>,
-    DefaultPageCache<MemAppPages>,
-) {
-    let (addr, kv, pages) = testing::app_pages_init(addr, page_count);
+) -> (Rc<RefCell<MemKVStore>>, DefaultPageCache<MemAppPages>) {
+    let (kv, pages) = testing::app_pages_init(page_count);
 
     let cache = DefaultPageCache::new(pages, page_count);
 
-    (addr, kv, cache)
+    (kv, cache)
 }
 
 /// Initialises a new page-cache backed by an existing in-memory pages-storage.
 pub fn app_page_cache_open(
-    addr: &Address,
     state: &State,
     kv: &Rc<RefCell<MemKVStore>>,
     page_count: u16,
 ) -> DefaultPageCache<MemAppPages> {
-    let pages = testing::app_pages_open(addr, state, kv, page_count);
+    let pages = testing::app_pages_open(state, kv, page_count);
 
     DefaultPageCache::new(pages, page_count)
 }

--- a/crates/svm-storage/src/testing/app_pages.rs
+++ b/crates/svm-storage/src/testing/app_pages.rs
@@ -1,30 +1,20 @@
-use std::cell::RefCell;
-use std::rc::Rc;
+use std::{cell::RefCell, rc::Rc};
 
-use svm_common::{Address, State};
+use svm_common::State;
 use svm_kv::memory::MemKVStore;
 
 use crate::memory::MemAppPages;
 
 /// Initializes a new app pages backed by a new in-memory key-value store.
-pub fn app_pages_init(
-    addr: &str,
-    page_count: u16,
-) -> (Address, Rc<RefCell<MemKVStore>>, MemAppPages) {
-    let addr = Address::of(addr);
+pub fn app_pages_init(page_count: u16) -> (Rc<RefCell<MemKVStore>>, MemAppPages) {
     let kv = Rc::new(RefCell::new(MemKVStore::new()));
 
-    let pages = MemAppPages::new(addr.clone(), Rc::clone(&kv), State::empty(), page_count);
+    let pages = MemAppPages::new(Rc::clone(&kv), State::empty(), page_count);
 
-    (addr, kv, pages)
+    (kv, pages)
 }
 
 /// Initializes a new app pages backed by an existing in-memory key-value store.
-pub fn app_pages_open(
-    addr: &Address,
-    state: &State,
-    kv: &Rc<RefCell<MemKVStore>>,
-    page_count: u16,
-) -> MemAppPages {
-    MemAppPages::new(addr.clone(), Rc::clone(&kv), state.clone(), page_count)
+pub fn app_pages_open(state: &State, kv: &Rc<RefCell<MemKVStore>>, page_count: u16) -> MemAppPages {
+    MemAppPages::new(Rc::clone(&kv), state.clone(), page_count)
 }

--- a/crates/svm-storage/src/testing/app_storage.rs
+++ b/crates/svm-storage/src/testing/app_storage.rs
@@ -1,32 +1,27 @@
-use std::cell::RefCell;
-use std::rc::Rc;
+use std::{cell::RefCell, rc::Rc};
 
 use crate::{testing, AppStorage};
 
-use svm_common::{Address, State};
+use svm_common::State;
 use svm_kv::memory::MemKVStore;
 
 /// Initialises a new `AppStorage` derived its address and #pages and empty state (`00...0`)
-pub fn app_storage_init(
-    addr: &str,
-    page_count: u16,
-) -> (Address, Rc<RefCell<MemKVStore>>, AppStorage) {
-    let (addr, kv, cache) = testing::app_page_cache_init(addr, page_count);
+pub fn app_storage_init(page_count: u16) -> (Rc<RefCell<MemKVStore>>, AppStorage) {
+    let (kv, cache) = testing::app_page_cache_init(page_count);
 
     let storage = AppStorage::new(Box::new(cache));
 
-    (addr, kv, storage)
+    (kv, storage)
 }
 
 /// Initialises a new `AppStorage` derived its address, state and #pages.
 /// Storage is backed by an key-value store `kv`
 pub fn app_storage_open(
-    addr: &Address,
     state: &State,
     kv: &Rc<RefCell<MemKVStore>>,
     page_count: u16,
 ) -> AppStorage {
-    let cache = testing::app_page_cache_open(addr, state, kv, page_count);
+    let cache = testing::app_page_cache_open(state, kv, page_count);
 
     AppStorage::new(Box::new(cache))
 }

--- a/crates/svm-storage/src/testing/page.rs
+++ b/crates/svm-storage/src/testing/page.rs
@@ -1,8 +1,8 @@
-use svm_common::{Address, DefaultKeyHasher, KeyHasher, State};
+use svm_common::{DefaultKeyHasher, KeyHasher, State};
 
 use crate::{
     default::DefaultPageHasher,
-    page::{JoinedPagesHash, PageHash, PageIndex},
+    page::{JoinedPagesHash, PageHash},
     traits::PageHasher,
 };
 

--- a/crates/svm-storage/src/traits.rs
+++ b/crates/svm-storage/src/traits.rs
@@ -1,6 +1,6 @@
 use crate::page::{JoinedPagesHash, PageHash, PageIndex};
 
-use svm_common::{Address, State};
+use svm_common::State;
 
 /// `PagesStorage` is the most low-level trait for dealing with a app's storage.
 /// For performance concerns, we work on pages units (a page is 4096 bytes)

--- a/crates/svm-storage/tests/app_page_cache_tests.rs
+++ b/crates/svm-storage/tests/app_page_cache_tests.rs
@@ -9,29 +9,30 @@ mod asserts;
 #[test]
 fn page_cache_loading_an_empty_page_into_the_cache() {
     let page_count = 10;
-    let (_addr, _kv, mut cache) = app_page_cache_init("my-app", page_count);
+    let (_kv, mut cache) = app_page_cache_init(page_count);
 
     assert_eq!(None, cache.read_page(PageIndex(0)));
 }
 
 #[test]
 fn page_cache_write_page_and_then_commit() {
-    let addr = "my-app";
     let page_count = 10;
-
-    let (_addr, kv, mut cache) = app_page_cache_init(addr, page_count);
+    let (kv, mut cache) = app_page_cache_init(page_count);
 
     cache.write_page(PageIndex(0), &[10, 20, 30]);
     assert_eq!(vec![10, 20, 30], cache.read_page(PageIndex(0)).unwrap());
 
     let ph = default_page_hash(&[10, 20, 30]);
-    assert_no_key!(kv, ph.0);
+    let key = ph.0;
+    let ns = vec![b'p'];
+
+    assert_no_key!(kv, ns, key);
 }
 
 #[test]
 fn page_cache_writing_a_page_marks_it_as_dirty() {
     let page_count = 10;
-    let (_addr, _kv, mut cache) = app_page_cache_init("my-app", page_count);
+    let (_kv, mut cache) = app_page_cache_init(page_count);
 
     assert_eq!(false, cache.is_dirty(0));
     cache.write_page(PageIndex(0), &[10, 20, 30]);
@@ -42,16 +43,16 @@ fn page_cache_writing_a_page_marks_it_as_dirty() {
 #[ignore]
 fn page_cache_commit_persists_each_dirty_page() {
     let page_count = 10;
-    let (_addr, kv, mut cache) = app_page_cache_init("my-app", page_count);
+    let (kv, mut cache) = app_page_cache_init(page_count);
 
     cache.write_page(PageIndex(0), &[10, 20, 30]);
 
     // `cache.write_page` doesn't persist the page yet
     let ph = default_page_hash(&[10, 20, 30]);
-    assert_no_key!(kv, ph.0);
+    let key = ph.0;
+    let ns = vec![b'p'];
 
+    assert_no_key!(kv, ns, key);
     cache.commit();
-
-    // `cache.commit` persists the page
-    assert_key_value!(kv, ph.0, [10, 20, 30]);
+    assert_key_value!(kv, ns, key, [10, 20, 30]);
 }

--- a/crates/svm-storage/tests/app_pages_tests.rs
+++ b/crates/svm-storage/tests/app_pages_tests.rs
@@ -14,7 +14,7 @@ mod asserts;
 #[test]
 fn app_pages_first_time_run_with_no_modifications_no_commit() {
     let page_count = 3;
-    let (_addr, _kv, mut pages) = app_pages_init("my-app", page_count);
+    let (_kv, mut pages) = app_pages_init(page_count);
 
     assert_eq!(0, pages.dirty_page_count());
     assert_eq!(None, pages.read_page(PageIndex(0)));
@@ -24,7 +24,7 @@ fn app_pages_first_time_run_with_no_modifications_no_commit() {
 #[test]
 fn app_pages_first_time_run_with_no_modifications_then_commit() {
     let page_count = 3;
-    let (_addr, kv, mut pages) = app_pages_init("my-app", page_count);
+    let (kv, mut pages) = app_pages_init(page_count);
     assert_eq!(0, pages.dirty_page_count());
 
     pages.commit();
@@ -38,7 +38,9 @@ fn app_pages_first_time_run_with_no_modifications_then_commit() {
 
     assert_same_keys!(vec![actual_state.bytes()], kv_keys_vec!(kv));
 
-    assert_no_key!(&kv, ph.0);
+    let ns = vec![b'p'];
+    let key = ph.0;
+    assert_no_key!(kv, ns, key);
 
     assert_page_content!(pages, 0, None);
     assert_page_content!(pages, 1, None);
@@ -50,7 +52,7 @@ fn app_pages_first_time_run_with_no_modifications_then_commit() {
 #[test]
 fn app_pages_first_time_run_with_one_modified_page() {
     let page_count = 2;
-    let (_addr, kv, mut pages) = app_pages_init("my-app", page_count);
+    let (kv, mut pages) = app_pages_init(page_count);
 
     pages.write_page(PageIndex(0), &[10, 20, 30]);
     assert_eq!(1, pages.dirty_page_count());
@@ -63,9 +65,11 @@ fn app_pages_first_time_run_with_one_modified_page() {
     let actual_state = pages.get_state();
     assert_eq!(expected_state, actual_state);
 
+    let ns = vec![b'p'];
+
     assert_same_keys!(vec![actual_state.bytes(), ph0.0], kv_keys_vec!(kv));
-    assert_key_value!(kv, actual_state.bytes(), concat_pages_hash(&[ph0, ph1]));
-    assert_key_value!(kv, ph0.0, [10, 20, 30]);
+    assert_key_value!(kv, ns, actual_state.bytes(), concat_pages_hash(&[ph0, ph1]));
+    assert_key_value!(kv, ns, ph0.0, [10, 20, 30]);
 
     assert_page_content!(pages, 0, Some(vec![10, 20, 30]));
     assert_page_content!(pages, 1, None);
@@ -76,7 +80,7 @@ fn app_pages_first_time_run_with_one_modified_page() {
 #[test]
 fn app_pages_first_time_run_with_two_modified_pages() {
     let page_count = 2;
-    let (_addr, kv, mut pages) = app_pages_init("my-app", page_count);
+    let (kv, mut pages) = app_pages_init(page_count);
 
     pages.write_page(PageIndex(0), &[10, 20, 30]);
     pages.write_page(PageIndex(1), &[40, 50, 60]);
@@ -90,10 +94,12 @@ fn app_pages_first_time_run_with_two_modified_pages() {
     let actual_state = pages.get_state();
     assert_eq!(expected_state, actual_state);
 
+    let ns = vec![b'p'];
+
     assert_same_keys!(vec![actual_state.bytes(), ph0.0, ph1.0], kv_keys_vec!(kv));
-    assert_key_value!(kv, actual_state.bytes(), concat_pages_hash(&[ph0, ph1]));
-    assert_key_value!(kv, ph0.0, [10, 20, 30]);
-    assert_key_value!(kv, ph1.0, [40, 50, 60]);
+    assert_key_value!(kv, ns, actual_state.bytes(), concat_pages_hash(&[ph0, ph1]));
+    assert_key_value!(kv, ns, ph0.0, [10, 20, 30]);
+    assert_key_value!(kv, ns, ph1.0, [40, 50, 60]);
 
     assert_page_content!(pages, 0, Some(vec![10, 20, 30]));
     assert_page_content!(pages, 1, Some(vec![40, 50, 60]));
@@ -106,12 +112,12 @@ fn app_pages_second_run_after_first_run_with_no_modifications() {
     // 1st run
     let page_count = 3;
 
-    let (addr, kv, mut pages) = app_pages_init("my-app", page_count);
+    let (kv, mut pages) = app_pages_init(page_count);
     pages.commit();
     let old_state = pages.get_state();
 
     // 2nd run
-    let mut pages = app_pages_open(&addr, &old_state, &kv, page_count);
+    let mut pages = app_pages_open(&old_state, &kv, page_count);
     pages.write_page(PageIndex(0), &[10, 20, 30]);
     pages.write_page(PageIndex(1), &[40, 50, 60]);
     pages.commit();
@@ -130,25 +136,32 @@ fn app_pages_second_run_after_first_run_with_no_modifications() {
         kv_keys_vec!(kv)
     );
 
-    assert_key_value!(kv, new_state.bytes(), concat_pages_hash(&[ph0, ph1, ph2]));
-    assert_key_value!(kv, ph0.0, [10, 20, 30]);
-    assert_key_value!(kv, ph0.0, [10, 20, 30]);
-    assert_key_value!(kv, ph1.0, [40, 50, 60]);
-    assert_no_key!(kv, ph2.0);
+    let ns = vec![b'p'];
+
+    assert_key_value!(
+        kv,
+        ns,
+        new_state.bytes(),
+        concat_pages_hash(&[ph0, ph1, ph2])
+    );
+    assert_key_value!(kv, ns, ph0.0, [10, 20, 30]);
+    assert_key_value!(kv, ns, ph0.0, [10, 20, 30]);
+    assert_key_value!(kv, ns, ph1.0, [40, 50, 60]);
+    assert_no_key!(kv, ns, ph2.0);
 }
 
 #[test]
 fn app_pages_second_run_after_first_run_with_modifications() {
     // 1st run
     let page_count = 3;
-    let (addr, kv, mut pages) = app_pages_init("my-app", page_count);
+    let (kv, mut pages) = app_pages_init(page_count);
 
     pages.write_page(PageIndex(0), &[11, 22, 33]);
     pages.commit();
     let old_state = pages.get_state();
 
     // 2nd run
-    let mut pages = app_pages_open(&addr, &old_state, &kv, page_count);
+    let mut pages = app_pages_open(&old_state, &kv, page_count);
     pages.write_page(PageIndex(0), &[10, 20, 30]);
     pages.write_page(PageIndex(1), &[40, 50, 60]);
     pages.commit();
@@ -174,28 +187,35 @@ fn app_pages_second_run_after_first_run_with_modifications() {
         kv_keys_vec!(kv)
     );
 
-    assert_key_value!(kv, new_state.bytes(), concat_pages_hash(&[ph0, ph1, ph2]));
-    assert_key_value!(kv, ph0.0, [10, 20, 30]);
-    assert_key_value!(kv, ph1.0, [40, 50, 60]);
-    assert_no_key!(kv, ph2.0);
+    let ns = vec![b'p'];
+    assert_key_value!(
+        kv,
+        ns,
+        new_state.bytes(),
+        concat_pages_hash(&[ph0, ph1, ph2])
+    );
+    assert_key_value!(kv, ns, ph0.0, [10, 20, 30]);
+    assert_key_value!(kv, ns, ph1.0, [40, 50, 60]);
+    assert_no_key!(kv, ns, ph2.0);
 }
 
 #[test]
 fn app_pages_third_run_rollbacks_to_after_first_run() {
     // 1st run
+    let ns = vec![b'p'];
     let page_count = 3;
-    let (addr, kv, mut pages) = app_pages_init("my-app", page_count);
+    let (kv, mut pages) = app_pages_init(page_count);
 
     pages.write_page(PageIndex(0), &[11, 22, 33]);
     pages.commit();
-    let state_1 = pages.get_state();
 
+    let state_1 = pages.get_state();
     let ph0_1 = default_page_hash(&[11, 22, 33]);
     let ph1_1 = default_page_hash(&zero_page());
     let ph2_1 = default_page_hash(&zero_page());
 
     // 2nd run
-    let mut pages = app_pages_open(&addr, &state_1, &kv, page_count);
+    let mut pages = app_pages_open(&state_1, &kv, page_count);
     pages.write_page(PageIndex(0), &[10, 20, 30]);
     pages.write_page(PageIndex(1), &[40, 50, 60]);
     pages.commit();
@@ -207,7 +227,7 @@ fn app_pages_third_run_rollbacks_to_after_first_run() {
     let ph2_2 = default_page_hash(&zero_page());
 
     // 3rd run (rollbacks to `state_1` initial state)
-    let pages = app_pages_open(&addr, &state_1, &kv, page_count);
+    let pages = app_pages_open(&state_1, &kv, page_count);
 
     assert_same_keys!(
         vec![state_1.bytes(), state_2.bytes(), ph0_1.0, ph0_2.0, ph1_2.0],
@@ -219,12 +239,13 @@ fn app_pages_third_run_rollbacks_to_after_first_run() {
 
     assert_key_value!(
         kv,
+        ns,
         state_1.bytes(),
         concat_pages_hash(&[ph0_1, ph1_1, ph2_1])
     );
 
     // 4th run (rollbacks to `state_2` state)
-    let pages = app_pages_open(&addr, &state_2, &kv, page_count);
+    let pages = app_pages_open(&state_2, &kv, page_count);
 
     assert_same_keys!(
         vec![state_1.bytes(), state_2.bytes(), ph0_1.0, ph0_2.0, ph1_2.0],
@@ -233,6 +254,7 @@ fn app_pages_third_run_rollbacks_to_after_first_run() {
 
     assert_key_value!(
         kv,
+        ns,
         state_2.bytes(),
         concat_pages_hash(&[ph0_2, ph1_2, ph2_2])
     );

--- a/crates/svm-storage/tests/app_pages_tests.rs
+++ b/crates/svm-storage/tests/app_pages_tests.rs
@@ -1,6 +1,5 @@
-extern crate svm_storage;
-
 use svm_common::State;
+use svm_kv::key::concat_ns_to_key;
 use svm_storage::{
     page::{zero_page, PageIndex},
     testing::{
@@ -36,10 +35,11 @@ fn app_pages_first_time_run_with_no_modifications_then_commit() {
 
     assert_eq!(expected_state, actual_state);
 
-    assert_same_keys!(vec![actual_state.bytes()], kv_keys_vec!(kv));
+    let expected_key = concat_ns_to_key(&[b's'], expected_state.as_slice());
+    assert_same_keys!(vec![expected_key], kv_keys_vec!(kv));
 
     let ns = vec![b'p'];
-    let key = ph.0;
+    let key = concat_ns_to_key(&ns, ph.0);
     assert_no_key!(kv, ns, key);
 
     assert_page_content!(pages, 0, None);
@@ -65,11 +65,16 @@ fn app_pages_first_time_run_with_one_modified_page() {
     let actual_state = pages.get_state();
     assert_eq!(expected_state, actual_state);
 
-    let ns = vec![b'p'];
+    let state = expected_state.bytes();
+    let page_ns = vec![b'p'];
+    let state_ns = vec![b's'];
+    let page_key = concat_ns_to_key(&page_ns, ph0.0);
+    let state_key = concat_ns_to_key(&state_ns, state);
+    let expected_keys = vec![page_key.clone(), state_key.clone()];
 
-    assert_same_keys!(vec![actual_state.bytes(), ph0.0], kv_keys_vec!(kv));
-    assert_key_value!(kv, ns, actual_state.bytes(), concat_pages_hash(&[ph0, ph1]));
-    assert_key_value!(kv, ns, ph0.0, [10, 20, 30]);
+    assert_same_keys!(expected_keys, kv_keys_vec!(kv));
+    assert_key_value!(kv, state_ns, state, concat_pages_hash(&[ph0, ph1]));
+    assert_key_value!(kv, page_ns, ph0.0, [10, 20, 30]);
 
     assert_page_content!(pages, 0, Some(vec![10, 20, 30]));
     assert_page_content!(pages, 1, None);
@@ -94,12 +99,18 @@ fn app_pages_first_time_run_with_two_modified_pages() {
     let actual_state = pages.get_state();
     assert_eq!(expected_state, actual_state);
 
-    let ns = vec![b'p'];
+    let state = expected_state.bytes();
+    let page_ns = vec![b'p'];
+    let state_ns = vec![b's'];
+    let page0_key = concat_ns_to_key(&page_ns, ph0.0);
+    let page1_key = concat_ns_to_key(&page_ns, ph1.0);
+    let state_key = concat_ns_to_key(&state_ns, state);
+    let expected_keys = vec![page0_key.clone(), page1_key.clone(), state_key.clone()];
 
-    assert_same_keys!(vec![actual_state.bytes(), ph0.0, ph1.0], kv_keys_vec!(kv));
-    assert_key_value!(kv, ns, actual_state.bytes(), concat_pages_hash(&[ph0, ph1]));
-    assert_key_value!(kv, ns, ph0.0, [10, 20, 30]);
-    assert_key_value!(kv, ns, ph1.0, [40, 50, 60]);
+    assert_same_keys!(expected_keys, kv_keys_vec!(kv));
+    assert_key_value!(kv, state_ns, state, concat_pages_hash(&[ph0, ph1]));
+    assert_key_value!(kv, page_ns, ph0.0, [10, 20, 30]);
+    assert_key_value!(kv, page_ns, ph1.0, [40, 50, 60]);
 
     assert_page_content!(pages, 0, Some(vec![10, 20, 30]));
     assert_page_content!(pages, 1, Some(vec![40, 50, 60]));
@@ -131,23 +142,27 @@ fn app_pages_second_run_after_first_run_with_no_modifications() {
     let new_state = pages.get_state();
     assert_eq!(expected_state, new_state);
 
-    assert_same_keys!(
-        vec![old_state.bytes(), new_state.bytes(), ph0.0, ph1.0],
-        kv_keys_vec!(kv)
-    );
+    let old_state = old_state.bytes();
+    let new_state = new_state.bytes();
+    let page_ns = vec![b'p'];
+    let state_ns = vec![b's'];
+    let old_state_key = concat_ns_to_key(&state_ns, old_state);
+    let new_state_key = concat_ns_to_key(&state_ns, new_state);
+    let page0_key = concat_ns_to_key(&page_ns, ph0.0);
+    let page1_key = concat_ns_to_key(&page_ns, ph1.0);
 
-    let ns = vec![b'p'];
+    let expected_keys = vec![
+        page0_key.clone(),
+        page1_key.clone(),
+        old_state_key.clone(),
+        new_state_key.clone(),
+    ];
 
-    assert_key_value!(
-        kv,
-        ns,
-        new_state.bytes(),
-        concat_pages_hash(&[ph0, ph1, ph2])
-    );
-    assert_key_value!(kv, ns, ph0.0, [10, 20, 30]);
-    assert_key_value!(kv, ns, ph0.0, [10, 20, 30]);
-    assert_key_value!(kv, ns, ph1.0, [40, 50, 60]);
-    assert_no_key!(kv, ns, ph2.0);
+    assert_same_keys!(expected_keys, kv_keys_vec!(kv));
+    assert_key_value!(kv, state_ns, new_state, concat_pages_hash(&[ph0, ph1, ph2]));
+    assert_key_value!(kv, page_ns, ph0.0, [10, 20, 30]);
+    assert_key_value!(kv, page_ns, ph1.0, [40, 50, 60]);
+    assert_no_key!(kv, page_ns, ph2.0);
 }
 
 #[test]
@@ -176,88 +191,101 @@ fn app_pages_second_run_after_first_run_with_modifications() {
     let new_state = pages.get_state();
     assert_eq!(expected_state, new_state);
 
-    assert_same_keys!(
-        vec![
-            old_state.bytes(),
-            new_state.bytes(),
-            ph0_old.0,
-            ph0.0,
-            ph1.0
-        ],
-        kv_keys_vec!(kv)
-    );
+    let old_state = old_state.bytes();
+    let new_state = new_state.bytes();
+    let page_ns = vec![b'p'];
+    let state_ns = vec![b's'];
+    let old_state_key = concat_ns_to_key(&state_ns, old_state);
+    let new_state_key = concat_ns_to_key(&state_ns, new_state);
+    let page0_old_key = concat_ns_to_key(&page_ns, ph0_old.0);
+    let page0_key = concat_ns_to_key(&page_ns, ph0.0);
+    let page1_key = concat_ns_to_key(&page_ns, ph1.0);
 
-    let ns = vec![b'p'];
-    assert_key_value!(
-        kv,
-        ns,
-        new_state.bytes(),
-        concat_pages_hash(&[ph0, ph1, ph2])
-    );
-    assert_key_value!(kv, ns, ph0.0, [10, 20, 30]);
-    assert_key_value!(kv, ns, ph1.0, [40, 50, 60]);
-    assert_no_key!(kv, ns, ph2.0);
+    let expected_keys = vec![
+        page0_old_key.clone(),
+        page0_key.clone(),
+        page1_key.clone(),
+        old_state_key.clone(),
+        new_state_key.clone(),
+    ];
+
+    assert_same_keys!(expected_keys, kv_keys_vec!(kv));
+    assert_key_value!(kv, state_ns, new_state, concat_pages_hash(&[ph0, ph1, ph2]));
+    assert_key_value!(kv, page_ns, ph0_old.0, [11, 22, 33]);
+    assert_key_value!(kv, page_ns, ph0.0, [10, 20, 30]);
+    assert_key_value!(kv, page_ns, ph1.0, [40, 50, 60]);
+    assert_no_key!(kv, page_ns, ph2.0);
 }
 
 #[test]
 fn app_pages_third_run_rollbacks_to_after_first_run() {
     // 1st run
-    let ns = vec![b'p'];
     let page_count = 3;
     let (kv, mut pages) = app_pages_init(page_count);
 
     pages.write_page(PageIndex(0), &[11, 22, 33]);
     pages.commit();
 
-    let state_1 = pages.get_state();
+    let state1 = pages.get_state();
     let ph0_1 = default_page_hash(&[11, 22, 33]);
     let ph1_1 = default_page_hash(&zero_page());
     let ph2_1 = default_page_hash(&zero_page());
 
     // 2nd run
-    let mut pages = app_pages_open(&state_1, &kv, page_count);
+    let mut pages = app_pages_open(&state1, &kv, page_count);
     pages.write_page(PageIndex(0), &[10, 20, 30]);
     pages.write_page(PageIndex(1), &[40, 50, 60]);
     pages.commit();
-    let state_2 = pages.get_state();
+    let state2 = pages.get_state();
 
     // modifying pages `0` and `1`
     let ph0_2 = default_page_hash(&[10, 20, 30]);
     let ph1_2 = default_page_hash(&[40, 50, 60]);
     let ph2_2 = default_page_hash(&zero_page());
 
-    // 3rd run (rollbacks to `state_1` initial state)
-    let pages = app_pages_open(&state_1, &kv, page_count);
+    // 3rd run (rollbacks to `state1` initial state)
+    let pages = app_pages_open(&state1, &kv, page_count);
 
-    assert_same_keys!(
-        vec![state_1.bytes(), state_2.bytes(), ph0_1.0, ph0_2.0, ph1_2.0],
-        kv_keys_vec!(kv)
-    );
+    let page_ns = vec![b'p'];
+    let state_ns = vec![b's'];
+
+    let state1_key = concat_ns_to_key(&state_ns, state1.bytes());
+    let state2_key = concat_ns_to_key(&state_ns, state2.bytes());
+    let page0_1_key = concat_ns_to_key(&page_ns, ph0_1.0);
+    let page0_2_key = concat_ns_to_key(&page_ns, ph0_2.0);
+    let page1_2_key = concat_ns_to_key(&page_ns, ph1_2.0);
+
+    let expected_keys = vec![
+        state1_key.clone(),
+        state2_key.clone(),
+        page0_1_key.clone(),
+        page0_2_key.clone(),
+        page1_2_key.clone(),
+    ];
+
+    assert_same_keys!(expected_keys, kv_keys_vec!(kv));
 
     let expected_state = compute_pages_state(&[ph0_1, ph1_1, ph2_1]);
     assert_eq!(expected_state, pages.get_state());
 
     assert_key_value!(
         kv,
-        ns,
-        state_1.bytes(),
+        state_ns,
+        state1.bytes(),
         concat_pages_hash(&[ph0_1, ph1_1, ph2_1])
     );
 
-    // 4th run (rollbacks to `state_2` state)
-    let pages = app_pages_open(&state_2, &kv, page_count);
+    // 4th run (rollbacks to `state2` state)
+    let pages = app_pages_open(&state2, &kv, page_count);
 
-    assert_same_keys!(
-        vec![state_1.bytes(), state_2.bytes(), ph0_1.0, ph0_2.0, ph1_2.0],
-        kv_keys_vec!(kv)
-    );
+    assert_same_keys!(expected_keys, kv_keys_vec!(kv));
 
     assert_key_value!(
         kv,
-        ns,
-        state_2.bytes(),
+        state_ns,
+        state2.bytes(),
         concat_pages_hash(&[ph0_2, ph1_2, ph2_2])
     );
 
-    assert_eq!(state_2, pages.get_state());
+    assert_eq!(state2, pages.get_state());
 }

--- a/crates/svm-storage/tests/app_storage_tests.rs
+++ b/crates/svm-storage/tests/app_storage_tests.rs
@@ -1,14 +1,15 @@
-use svm_kv::traits::KVStore;
-
-use svm_storage::page::{zero_page, PageIndex, PageOffset, PageSliceLayout};
-use svm_storage::testing::{app_storage_init, app_storage_open, default_page_hash, fill_page};
-
 mod asserts;
+
+use svm_kv::traits::KVStore;
+use svm_storage::{
+    page::{zero_page, PageIndex, PageOffset, PageSliceLayout},
+    testing::{app_storage_init, app_storage_open, default_page_hash, fill_page},
+};
 
 #[test]
 fn app_storage_loading_an_empty_slice_into_the_cache() {
     let page_count = 10;
-    let (_addr, _kv, mut storage) = app_storage_init("my-app", page_count);
+    let (_kv, mut storage) = app_storage_init(page_count);
 
     let layout = PageSliceLayout::new(PageIndex(1), PageOffset(100), 200);
 
@@ -18,7 +19,8 @@ fn app_storage_loading_an_empty_slice_into_the_cache() {
 #[test]
 fn app_storage_read_an_empty_slice_then_override_it_and_then_commit() {
     let page_count = 10;
-    let (_addr, kv, mut storage) = app_storage_init("my-app", page_count);
+
+    let (kv, mut storage) = app_storage_init(page_count);
 
     let layout = PageSliceLayout::new(PageIndex(1), PageOffset(100), 3);
 
@@ -30,13 +32,16 @@ fn app_storage_read_an_empty_slice_then_override_it_and_then_commit() {
 
     // page is not persisted though since we didn't `commit`
     let ph = default_page_hash(&[10, 20, 30]);
-    assert_no_key!(&kv, ph.0);
+    let ns = vec![b'p'];
+    let key = ph.0;
+
+    assert_no_key!(kv, ns, key);
 }
 
 #[test]
 fn app_storage_write_slice_without_loading_it_first_and_commit() {
     let page_count = 2;
-    let (addr, kv, mut storage) = app_storage_init("my-app", page_count);
+    let (kv, mut storage) = app_storage_init(page_count);
 
     // page #1, cells: `100, 1001, 1002`
     let layout = PageSliceLayout::new(PageIndex(1), PageOffset(100), 3);
@@ -45,7 +50,7 @@ fn app_storage_write_slice_without_loading_it_first_and_commit() {
     let new_state = storage.commit();
 
     // asserting persisted data. when viewed in the context of `new_state`.
-    app_storage_open(&addr, &new_state, &kv, page_count);
+    app_storage_open(&new_state, &kv, page_count);
 
     assert_eq!(vec![10, 20, 30], storage.read_page_slice(&layout));
 
@@ -53,14 +58,17 @@ fn app_storage_write_slice_without_loading_it_first_and_commit() {
     fill_page(&mut expected_page, &[(100, 10), (101, 20), (102, 30)]);
 
     let ph = default_page_hash(&expected_page);
+    let ns = vec![b'p'];
+    let key = ph.0;
 
-    assert_key_value!(kv, ph.0, expected_page);
+    assert_key_value!(kv, ns, key, expected_page);
 }
 
 #[test]
 fn app_storage_read_an_existing_slice_then_overriding_it_and_commit() {
     let page_count = 2;
-    let (_addr, kv, mut storage) = app_storage_init("my-app", page_count);
+    let ns = vec![b'p'];
+    let (kv, mut storage) = app_storage_init(page_count);
 
     let layout = PageSliceLayout::new(PageIndex(1), PageOffset(100), 3);
 
@@ -73,29 +81,30 @@ fn app_storage_read_an_existing_slice_then_overriding_it_and_commit() {
     fill_page(&mut expected_page, &[(100, 40), (101, 50), (102, 60)]);
     let ph2 = default_page_hash(&expected_page);
 
-    let page = kv.borrow().get(&ph1.0).unwrap();
+    let page = kv.borrow().get(&ns, &ph1.0).unwrap();
     assert_eq!(vec![10, 20, 30], &page[100..103]);
     storage.write_page_slice(&layout, &vec![40, 50, 60]);
 
     // new page is on the page-storage, but not persisted yet
     assert_eq!(vec![40, 50, 60], storage.read_page_slice(&layout));
 
-    let page = kv.borrow().get(&ph1.0).unwrap();
+    let page = kv.borrow().get(&ns, &ph1.0).unwrap();
     assert_eq!(vec![10, 20, 30], &page[100..103]);
 
-    assert_eq!(None, kv.borrow().get(&ph2.0));
+    assert_eq!(None, kv.borrow().get(&ns, &ph2.0));
 
     // now we also persist the new page version
     let _ = storage.commit();
 
-    let page = kv.borrow().get(&ph2.0).unwrap();
+    let page = kv.borrow().get(&ns, &ph2.0).unwrap();
     assert_eq!(vec![40, 50, 60], &page[100..103]);
 }
 
 #[test]
 fn app_storage_write_slice_and_commit_then_load_it_override_it_and_commit() {
     let page_count = 2;
-    let (addr, kv, mut storage) = app_storage_init("my-app", page_count);
+    let ns = vec![b'p'];
+    let (kv, mut storage) = app_storage_init(page_count);
 
     let layout = PageSliceLayout::new(PageIndex(1), PageOffset(100), 3);
 
@@ -112,7 +121,7 @@ fn app_storage_write_slice_and_commit_then_load_it_override_it_and_commit() {
     let state = storage.commit();
 
     // 3) re-load persisted page (we do a `clear` first to make sure we load from the pages-storage)
-    let mut storage = app_storage_open(&addr, &state, &kv, page_count);
+    let mut storage = app_storage_open(&state, &kv, page_count);
     assert_eq!(vec![10, 20, 30], storage.read_page_slice(&layout));
 
     // 4) page override
@@ -120,19 +129,19 @@ fn app_storage_write_slice_and_commit_then_load_it_override_it_and_commit() {
     assert_eq!(vec![40, 50, 60], storage.read_page_slice(&layout));
 
     // 5) commit again
-    let page = kv.borrow().get(&ph1.0).unwrap();
+    let page = kv.borrow().get(&ns, &ph1.0).unwrap();
     assert_eq!(vec![10, 20, 30], &page[100..103]);
 
     let _ = storage.commit();
 
-    let page = kv.borrow().get(&ph2.0).unwrap();
+    let page = kv.borrow().get(&ns, &ph2.0).unwrap();
     assert_eq!(vec![40, 50, 60], &page[100..103]);
 }
 
 #[test]
 fn app_storage_write_two_slices_under_same_page_and_commit() {
     let page_count = 2;
-    let (addr, kv, mut storage) = app_storage_init("my-app", page_count);
+    let (kv, mut storage) = app_storage_init(page_count);
 
     let layout1 = PageSliceLayout::new(PageIndex(1), PageOffset(100), 3);
     let layout2 = PageSliceLayout::new(PageIndex(1), PageOffset(200), 2);
@@ -152,18 +161,20 @@ fn app_storage_write_two_slices_under_same_page_and_commit() {
     assert_eq!(vec![40, 50], storage.read_page_slice(&layout2));
 
     // commiting two slices under the same page
-    assert_no_key!(kv, ph.0);
+    let ns = vec![b'p'];
+    let key = ph.0;
+    assert_no_key!(kv, ns, key);
 
     let state = storage.commit();
 
     // asserting persisted data. when viewing in the context of `new_state`.
-    let mut storage = app_storage_open(&addr, &state, &kv, page_count);
+    let mut storage = app_storage_open(&state, &kv, page_count);
 
     assert_eq!(vec![10, 20, 30], storage.read_page_slice(&layout1));
     assert_eq!(vec![40, 50], storage.read_page_slice(&layout2));
 
     // querying the key-value store directly
-    let page = kv.borrow().get(&ph.0).unwrap();
+    let page = kv.borrow().get(&ns, &ph.0).unwrap();
     assert_eq!(vec![10, 20, 30], &page[100..103]);
     assert_eq!(vec![40, 50], &page[200..202]);
 }

--- a/crates/svm-storage/tests/asserts.rs
+++ b/crates/svm-storage/tests/asserts.rs
@@ -1,32 +1,32 @@
 #[macro_export]
 macro_rules! assert_no_key {
-    ($kv: expr, $key: expr) => {{
+    ($kv:expr, $ns:expr, $key: expr) => {{
         use svm_kv::traits::KVStore;
 
-        assert!($kv.borrow().get(&$key).is_none());
+        assert!($kv.borrow().get(&$ns, &$key).is_none());
     }};
 }
 
 #[macro_export]
 macro_rules! assert_key_value {
-    ($kv: expr, $key: expr, $expected: expr) => {{
+    ($kv:expr, $ns:expr, $key:expr, $expected:expr) => {{
         use svm_kv::traits::KVStore;
 
-        let actual = $kv.borrow().get(&$key).unwrap();
+        let actual = $kv.borrow().get(&$ns, &$key).unwrap();
         assert_eq!($expected, &actual[..]);
     }};
 }
 
 #[macro_export]
 macro_rules! assert_page_content {
-    ($pages: ident, $page_idx: expr, $expected: expr) => {{
+    ($pages:ident, $page_idx:expr, $expected:expr) => {{
         assert_eq!($expected, $pages.read_page(PageIndex($page_idx)));
     }};
 }
 
 #[macro_export]
 macro_rules! kv_keys_vec {
-    ($kv: ident) => {{
+    ($kv:ident) => {{
         let keys: Vec<Vec<u8>> = $kv.borrow().keys().map(|key| key.clone()).collect();
         keys
     }};


### PR DESCRIPTION
# Motivation
Adding logical isolation to the keys stored under SVM.
Each key will have a namespace prefix and a `:` separator.
In case an empty namespace is used for a key then no `:` separator will be used.

Examples:
* Keys for app-state will be `st` (usage: `st:A19F...`)
* Keys of app-pages data will be `p`  (usage: `p:A19F...`)
* Keys of templates will be `t`   (usage: `t:A19F...`)



