### PR TITLE
Receipt helper for extracting `returns`

### DIFF
--- a/crates/svm-runtime-c-api/src/api.rs
+++ b/crates/svm-runtime-c-api/src/api.rs
@@ -1028,26 +1028,33 @@ pub unsafe extern "C" fn svm_exec_receipt_state(
     }
 }
 
-// #[no_mangle]
-// pub unsafe extern "C" fn svm_exec_receipt_returns(
-//     returns: *mut svm_value_array,
-//     receipt: svm_byte_array,
-//     error: *mut svm_byte_array,
-// ) -> svm_result_t {
-//     let client_receipt = testing::decode_exec_receipt(receipt.into());
-//
-//     match client_receipt {
-//         ClientExecReceipt::Success { func_returns, .. } => {
-//             let func_returns: svm_value_array = func_returns.into();
-//             // *returns = ;
-//             svm_result_t::SVM_SUCCESS
-//         }
-//         ClientExecReceipt::Failure { error: err_str } => {
-//             raw_error(err_str, error);
-//             svm_result_t::SVM_FAILURE
-//         }
-//     }
-// }
+/// Extracts the `Exec App` returns.
+/// If it succeeded, returns `SVM_SUCCESS`,
+/// Otherwise returns `SVM_FAILURE` and the error message via `error` parameter.
+///
+/// # Panics
+///
+/// Panics when `receipt` input is invalid.
+///
+#[no_mangle]
+pub unsafe extern "C" fn svm_exec_receipt_returns(
+    returns: *mut svm_value_array,
+    receipt: svm_byte_array,
+    error: *mut svm_byte_array,
+) -> svm_result_t {
+    let client_receipt = testing::decode_exec_receipt(receipt.into());
+
+    match client_receipt {
+        ClientExecReceipt::Success { func_returns, .. } => {
+            *returns = func_returns.into();
+            svm_result_t::SVM_SUCCESS
+        }
+        ClientExecReceipt::Failure { error: err_str } => {
+            raw_error(err_str, error);
+            svm_result_t::SVM_FAILURE
+        }
+    }
+}
 
 /// Extracts the executed transaction `gas_used`.
 /// When transaction succeeded returns `SVM_SUCCESS`, returns the amount of gas used via `gas_used` parameter.

--- a/crates/svm-runtime-c-api/src/api.rs
+++ b/crates/svm-runtime-c-api/src/api.rs
@@ -914,6 +914,34 @@ pub unsafe extern "C" fn svm_app_receipt_addr(
     }
 }
 
+/// Extracts the spawned-app constructor returns.
+/// If it succeeded, returns `SVM_SUCCESS`,
+/// Otherwise returns `SVM_FAILURE` and the error message via `error` parameter.
+///
+/// # Panics
+///
+/// Panics when `receipt` input is invalid.
+///
+#[no_mangle]
+pub unsafe extern "C" fn svm_app_receipt_returns(
+    returns: *mut svm_value_array,
+    receipt: svm_byte_array,
+    error: *mut svm_byte_array,
+) -> svm_result_t {
+    let client_receipt = testing::decode_app_receipt(receipt.into());
+
+    match client_receipt {
+        ClientAppReceipt::Success { ctor_returns, .. } => {
+            *returns = ctor_returns.into();
+            svm_result_t::SVM_SUCCESS
+        }
+        ClientAppReceipt::Failure { error: err_str } => {
+            raw_error(err_str, error);
+            svm_result_t::SVM_FAILURE
+        }
+    }
+}
+
 /// Extracts the `gas_used` for spawned-app (including running its constructor).
 /// When spawn succeeded returns `SVM_SUCCESS`, returns the amount of gas used via `gas_used` parameter.
 /// Othewrise, returns `SVM_FAILURE` and the error message via the `error` parameter.

--- a/crates/svm-runtime-c-api/src/api.rs
+++ b/crates/svm-runtime-c-api/src/api.rs
@@ -10,7 +10,7 @@ use crate::{
     helpers, raw_error, raw_utf8_error, raw_validate_error,
     receipt::{encode_app_receipt, encode_exec_receipt, encode_template_receipt},
     svm_byte_array, svm_import_func_sig_t, svm_import_func_t, svm_import_kind, svm_import_t,
-    svm_import_value, svm_result_t, svm_value_type_array,
+    svm_import_value, svm_result_t, svm_value_array, svm_value_type_array,
     testing::{self, ClientAppReceipt, ClientExecReceipt, ClientTemplateReceipt},
     RuntimePtr,
 };
@@ -1027,6 +1027,27 @@ pub unsafe extern "C" fn svm_exec_receipt_state(
         }
     }
 }
+
+// #[no_mangle]
+// pub unsafe extern "C" fn svm_exec_receipt_returns(
+//     returns: *mut svm_value_array,
+//     receipt: svm_byte_array,
+//     error: *mut svm_byte_array,
+// ) -> svm_result_t {
+//     let client_receipt = testing::decode_exec_receipt(receipt.into());
+//
+//     match client_receipt {
+//         ClientExecReceipt::Success { func_returns, .. } => {
+//             let func_returns: svm_value_array = func_returns.into();
+//             // *returns = ;
+//             svm_result_t::SVM_SUCCESS
+//         }
+//         ClientExecReceipt::Failure { error: err_str } => {
+//             raw_error(err_str, error);
+//             svm_result_t::SVM_FAILURE
+//         }
+//     }
+// }
 
 /// Extracts the executed transaction `gas_used`.
 /// When transaction succeeded returns `SVM_SUCCESS`, returns the amount of gas used via `gas_used` parameter.

--- a/crates/svm-runtime-c-api/src/lib.rs
+++ b/crates/svm-runtime-c-api/src/lib.rs
@@ -40,7 +40,7 @@ pub use import::{
     svm_import_func_sig_t, svm_import_func_t, svm_import_kind, svm_import_t, svm_import_value,
 };
 pub use result::svm_result_t;
-pub use value::{svm_value_type, svm_value_type_array};
+pub use value::{svm_value, svm_value_array, svm_value_type, svm_value_type_array};
 
 mod runtime_ptr;
 pub use runtime_ptr::RuntimePtr;

--- a/crates/svm-runtime-c-api/src/receipt/exec_app.rs
+++ b/crates/svm-runtime-c-api/src/receipt/exec_app.rs
@@ -96,7 +96,7 @@ mod tests {
 
         let expected = ClientExecReceipt::Success {
             new_state: new_state.clone(),
-            func_returns: "".to_string(),
+            func_returns: Vec::new(),
             gas_used: 100,
         };
 
@@ -121,7 +121,7 @@ mod tests {
 
         let expected = ClientExecReceipt::Success {
             new_state: new_state.clone(),
-            func_returns: "I32(10), I64(20), I32(30)".to_string(),
+            func_returns: vec![WasmValue::I32(10), WasmValue::I64(20), WasmValue::I32(30)],
             gas_used: 100,
         };
 

--- a/crates/svm-runtime-c-api/src/receipt/spawn_app.rs
+++ b/crates/svm-runtime-c-api/src/receipt/spawn_app.rs
@@ -107,7 +107,7 @@ mod tests {
         let expected = ClientAppReceipt::Success {
             addr: addr.clone(),
             init_state: init_state.clone(),
-            ctor_returns: "".to_string(),
+            ctor_returns: Vec::new(),
             gas_used: 100,
         };
 
@@ -135,7 +135,7 @@ mod tests {
         let expected = ClientAppReceipt::Success {
             addr: addr.clone(),
             init_state: init_state.clone(),
-            ctor_returns: "I32(10), I64(20), I32(30)".to_string(),
+            ctor_returns: vec![WasmValue::I32(10), WasmValue::I64(20), WasmValue::I32(30)],
             gas_used: 100,
         };
 

--- a/crates/svm-runtime-c-api/src/testing/receipt/exec_app.rs
+++ b/crates/svm-runtime-c-api/src/testing/receipt/exec_app.rs
@@ -1,6 +1,9 @@
 use svm_common::State;
 
-use svm_app::raw::{decode_func_args, decode_version, NibbleIter};
+use svm_app::{
+    raw::{decode_func_args, decode_version, NibbleIter},
+    types::WasmValue,
+};
 
 use super::helpers;
 
@@ -13,7 +16,7 @@ pub enum ClientExecReceipt {
         new_state: State,
 
         /// The values returns by the invoked app as a string
-        func_returns: String,
+        func_returns: Vec<WasmValue>,
 
         /// The gas used during the transaction
         gas_used: u64,
@@ -45,13 +48,13 @@ pub fn decode_exec_receipt(bytes: &[u8]) -> ClientExecReceipt {
         1 => {
             // success
             let new_state = helpers::decode_state(&mut iter);
-            let returns = decode_func_args(&mut iter).unwrap();
+            let func_returns = decode_func_args(&mut iter).unwrap();
             let gas_used = helpers::decode_gas_used(&mut iter);
 
             ClientExecReceipt::Success {
                 new_state,
                 gas_used,
-                func_returns: helpers::wasm_values_str(&returns[..]),
+                func_returns,
             }
         }
         _ => unreachable!(),

--- a/crates/svm-runtime-c-api/src/testing/receipt/helpers.rs
+++ b/crates/svm-runtime-c-api/src/testing/receipt/helpers.rs
@@ -1,7 +1,4 @@
-use svm_app::{
-    raw::{self, Field, Nibble, NibbleIter},
-    types::WasmValue,
-};
+use svm_app::raw::{self, Field, Nibble, NibbleIter};
 use svm_common::{Address, State};
 
 pub(crate) fn decode_is_success(iter: &mut NibbleIter) -> u8 {
@@ -30,17 +27,4 @@ pub(crate) fn decode_address(iter: &mut NibbleIter) -> Address {
 
 pub(crate) fn decode_gas_used(iter: &mut NibbleIter) -> u64 {
     raw::decode_gas_used(iter).unwrap()
-}
-
-pub(crate) fn wasm_values_str(values: &[WasmValue]) -> String {
-    let mut buf = String::new();
-
-    for (i, v) in values.iter().enumerate() {
-        if i != 0 {
-            buf.push_str(", ");
-        }
-        buf.push_str(&format!("{:?}", v));
-    }
-
-    buf
 }

--- a/crates/svm-runtime-c-api/src/testing/receipt/spawn_app.rs
+++ b/crates/svm-runtime-c-api/src/testing/receipt/spawn_app.rs
@@ -1,8 +1,7 @@
 use svm_app::{
     raw::{decode_func_args, decode_version, NibbleIter},
-    types::AppAddr,
+    types::{AppAddr, WasmValue},
 };
-
 use svm_common::State;
 
 use super::helpers;
@@ -19,7 +18,7 @@ pub enum ClientAppReceipt {
         init_state: State,
 
         /// The values returned by the App's ctor, concatenated as a string
-        ctor_returns: String,
+        ctor_returns: Vec<WasmValue>,
 
         /// The gas used during the transaction
         gas_used: u64,
@@ -59,7 +58,7 @@ pub fn decode_app_receipt(bytes: &[u8]) -> ClientAppReceipt {
                 addr: addr.into(),
                 init_state,
                 gas_used,
-                ctor_returns: helpers::wasm_values_str(&ctor_returns[..]),
+                ctor_returns,
             }
         }
         _ => unreachable!(),


### PR DESCRIPTION
# Motivation

Adding Receipt helper for extracting the spawned-app `ctor_returns` and executed-app `func_returns`.