### PR TITLE
Remove dry run flag

### DIFF
--- a/crates/svm-runtime-c-api/src/api.rs
+++ b/crates/svm-runtime-c-api/src/api.rs
@@ -433,7 +433,6 @@ pub unsafe extern "C" fn svm_runtime_create(
 /// let template_bytes = svm_byte_array::default();
 /// let gas_metering = false;
 /// let gas_limit = 0;
-/// let dry_run = false;
 ///
 /// let res = unsafe {
 ///   svm_deploy_template(
@@ -444,7 +443,6 @@ pub unsafe extern "C" fn svm_runtime_create(
 ///     host_ctx,
 ///     gas_metering,
 ///     gas_limit,
-///     dry_run,
 ///     &mut error)
 /// };
 ///
@@ -461,7 +459,6 @@ pub unsafe extern "C" fn svm_deploy_template(
     host_ctx: svm_byte_array,
     gas_metering: bool,
     gas_limit: u64,
-    dry_run: bool,
     error: *mut svm_byte_array,
 ) -> svm_result_t {
     debug!("`svm_deploy_template` start`");
@@ -489,7 +486,6 @@ pub unsafe extern "C" fn svm_deploy_template(
         &author.unwrap().into(),
         host_ctx.unwrap(),
         gas_limit,
-        dry_run,
     );
 
     let mut receipt_bytes = encode_template_receipt(&rust_receipt);
@@ -534,7 +530,6 @@ pub unsafe extern "C" fn svm_deploy_template(
 /// let app_bytes = svm_byte_array::default();
 /// let gas_metering = false;
 /// let gas_limit = 0;
-/// let dry_run = false;
 ///
 /// let _res = unsafe {
 ///   svm_spawn_app(
@@ -545,7 +540,6 @@ pub unsafe extern "C" fn svm_deploy_template(
 ///     host_ctx,
 ///     gas_metering,
 ///     gas_limit,
-///     dry_run,
 ///     &mut error)
 /// };
 /// ```
@@ -560,7 +554,6 @@ pub unsafe extern "C" fn svm_spawn_app(
     host_ctx: svm_byte_array,
     gas_metering: bool,
     gas_limit: u64,
-    dry_run: bool,
     error: *mut svm_byte_array,
 ) -> svm_result_t {
     debug!("`svm_spawn_app` start");
@@ -587,7 +580,6 @@ pub unsafe extern "C" fn svm_spawn_app(
         &creator.unwrap().into(),
         host_ctx.unwrap(),
         gas_limit,
-        dry_run,
     );
 
     let mut receipt_bytes = encode_app_receipt(&rust_receipt);
@@ -633,7 +625,6 @@ pub unsafe extern "C" fn svm_spawn_app(
 /// let state = State::empty().into();
 /// let host_ctx = svm_byte_array::default();
 /// let gas_metering = false;
-/// let dry_run = false;
 /// let gas_limit = 0;
 ///
 /// let _res = unsafe {
@@ -645,7 +636,6 @@ pub unsafe extern "C" fn svm_spawn_app(
 ///     host_ctx,
 ///     gas_metering,
 ///     gas_limit,
-///     dry_run,
 ///     &mut error)
 /// };
 /// ```
@@ -660,7 +650,6 @@ pub unsafe extern "C" fn svm_exec_app(
     host_ctx: svm_byte_array,
     gas_metering: bool,
     gas_limit: u64,
-    dry_run: bool,
     error: *mut svm_byte_array,
 ) -> svm_result_t {
     debug!("`svm_exec_app` start");
@@ -683,8 +672,7 @@ pub unsafe extern "C" fn svm_exec_app(
 
     let gas_limit = maybe_gas!(gas_metering, gas_limit);
 
-    let rust_receipt =
-        runtime.exec_app(bytes.into(), &state.unwrap(), host_ctx, gas_limit, dry_run);
+    let rust_receipt = runtime.exec_app(bytes.into(), &state.unwrap(), host_ctx, gas_limit);
     let mut receipt_bytes = encode_exec_receipt(&rust_receipt);
 
     // returning encoded `ExecReceipt` as `svm_byte_array`.

--- a/crates/svm-runtime-c-api/src/api.rs
+++ b/crates/svm-runtime-c-api/src/api.rs
@@ -1028,26 +1028,33 @@ pub unsafe extern "C" fn svm_exec_receipt_state(
     }
 }
 
-// #[no_mangle]
-// pub unsafe extern "C" fn svm_exec_receipt_returns(
-//     returns: *mut svm_value_array,
-//     receipt: svm_byte_array,
-//     error: *mut svm_byte_array,
-// ) -> svm_result_t {
-//     let client_receipt = testing::decode_exec_receipt(receipt.into());
-//
-//     match client_receipt {
-//         ClientExecReceipt::Success { func_returns, .. } => {
-//             let func_returns: svm_value_array = func_returns.into();
-//             // *returns = ;
-//             svm_result_t::SVM_SUCCESS
-//         }
-//         ClientExecReceipt::Failure { error: err_str } => {
-//             raw_error(err_str, error);
-//             svm_result_t::SVM_FAILURE
-//         }
-//     }
-// }
+/// Extracts the `Exec App` returns.
+/// If it succeeded, returns `SVM_SUCCESS`,
+/// Otherwise returns `SVM_FAILURE` and the error message via `error` parameter.
+///
+/// # Panics
+///
+/// Panics when `receipt` input is invalid.
+///
+#[no_mangle]
+pub unsafe extern "C" fn svm_exec_receipt_returns(
+    returns: *mut svm_value_array,
+    receipt: svm_byte_array,
+    error: *mut svm_byte_array,
+) -> svm_result_t {
+    let client_receipt = testing::decode_exec_receipt(receipt.into());
+
+    match client_receipt {
+        ClientExecReceipt::Success { func_returns, .. } => {
+            *returns = func_returns.into();
+            svm_result_t::SVM_SUCCESS
+        }
+        ClientExecReceipt::Failure { error: err_str } => {
+            raw_error(err_str, error);
+            svm_result_t::SVM_FAILURE
+        }
+    }
+}
 
 /// Extracts the executed transaction `gas_used`.
 /// When transaction succeeded returns `SVM_SUCCESS`, returns the amount of gas used via `gas_used` parameter.

--- a/crates/svm-runtime-c-api/src/api.rs
+++ b/crates/svm-runtime-c-api/src/api.rs
@@ -914,6 +914,34 @@ pub unsafe extern "C" fn svm_app_receipt_addr(
     }
 }
 
+/// Extracts the spawned-app constructor returns.
+/// If it succeeded, returns `SVM_SUCCESS`,
+/// Otherwise returns `SVM_FAILURE` and the error message via `error` parameter.
+///
+/// # Panics
+///
+/// Panics when `receipt` input is invalid.
+///
+#[no_mangle]
+pub unsafe extern "C" fn svm_app_receipt_returns(
+    returns: *mut svm_value_array,
+    receipt: svm_byte_array,
+    error: *mut svm_byte_array,
+) -> svm_result_t {
+    let client_receipt = testing::decode_app_receipt(receipt.into());
+
+    match client_receipt {
+        ClientAppReceipt::Success { ctor_returns, .. } => {
+            *returns = ctor_returns.into();
+            svm_result_t::SVM_SUCCESS
+        }
+        ClientAppReceipt::Failure { error: err_str } => {
+            raw_error(err_str, error);
+            svm_result_t::SVM_FAILURE
+        }
+    }
+}
+
 /// Extracts the `gas_used` for spawned-app (including running its constructor).
 /// When spawn succeeded returns `SVM_SUCCESS`, returns the amount of gas used via `gas_used` parameter.
 /// Othewrise, returns `SVM_FAILURE` and the error message via the `error` parameter.

--- a/crates/svm-runtime-c-api/src/api.rs
+++ b/crates/svm-runtime-c-api/src/api.rs
@@ -10,7 +10,7 @@ use crate::{
     helpers, raw_error, raw_utf8_error, raw_validate_error,
     receipt::{encode_app_receipt, encode_exec_receipt, encode_template_receipt},
     svm_byte_array, svm_import_func_sig_t, svm_import_func_t, svm_import_kind, svm_import_t,
-    svm_import_value, svm_result_t, svm_value_type_array,
+    svm_import_value, svm_result_t, svm_value_array, svm_value_type_array,
     testing::{self, ClientAppReceipt, ClientExecReceipt, ClientTemplateReceipt},
     RuntimePtr,
 };
@@ -1027,6 +1027,27 @@ pub unsafe extern "C" fn svm_exec_receipt_state(
         }
     }
 }
+
+// #[no_mangle]
+// pub unsafe extern "C" fn svm_exec_receipt_returns(
+//     returns: *mut svm_value_array,
+//     receipt: svm_byte_array,
+//     error: *mut svm_byte_array,
+// ) -> svm_result_t {
+//     let client_receipt = testing::decode_exec_receipt(receipt.into());
+//
+//     match client_receipt {
+//         ClientExecReceipt::Success { func_returns, .. } => {
+//             let func_returns: svm_value_array = func_returns.into();
+//             // *returns = ;
+//             svm_result_t::SVM_SUCCESS
+//         }
+//         ClientExecReceipt::Failure { error: err_str } => {
+//             raw_error(err_str, error);
+//             svm_result_t::SVM_FAILURE
+//         }
+//     }
+// }
 
 /// Extracts the executed transaction `gas_used`.
 /// When transaction succeeded returns `SVM_SUCCESS`, returns the amount of gas used via `gas_used` parameter.

--- a/crates/svm-runtime-c-api/src/lib.rs
+++ b/crates/svm-runtime-c-api/src/lib.rs
@@ -40,7 +40,7 @@ pub use import::{
     svm_import_func_sig_t, svm_import_func_t, svm_import_kind, svm_import_t, svm_import_value,
 };
 pub use result::svm_result_t;
-pub use value::{svm_value_type, svm_value_type_array};
+pub use value::{svm_value, svm_value_array, svm_value_type, svm_value_type_array};
 
 mod runtime_ptr;
 pub use runtime_ptr::RuntimePtr;

--- a/crates/svm-runtime-c-api/src/receipt/exec_app.rs
+++ b/crates/svm-runtime-c-api/src/receipt/exec_app.rs
@@ -96,7 +96,7 @@ mod tests {
 
         let expected = ClientExecReceipt::Success {
             new_state: new_state.clone(),
-            func_returns: "".to_string(),
+            func_returns: Vec::new(),
             gas_used: 100,
         };
 
@@ -121,7 +121,7 @@ mod tests {
 
         let expected = ClientExecReceipt::Success {
             new_state: new_state.clone(),
-            func_returns: "I32(10), I64(20), I32(30)".to_string(),
+            func_returns: vec![WasmValue::I32(10), WasmValue::I64(20), WasmValue::I32(30)],
             gas_used: 100,
         };
 

--- a/crates/svm-runtime-c-api/src/receipt/spawn_app.rs
+++ b/crates/svm-runtime-c-api/src/receipt/spawn_app.rs
@@ -107,7 +107,7 @@ mod tests {
         let expected = ClientAppReceipt::Success {
             addr: addr.clone(),
             init_state: init_state.clone(),
-            ctor_returns: "".to_string(),
+            ctor_returns: Vec::new(),
             gas_used: 100,
         };
 
@@ -135,7 +135,7 @@ mod tests {
         let expected = ClientAppReceipt::Success {
             addr: addr.clone(),
             init_state: init_state.clone(),
-            ctor_returns: "I32(10), I64(20), I32(30)".to_string(),
+            ctor_returns: vec![WasmValue::I32(10), WasmValue::I64(20), WasmValue::I32(30)],
             gas_used: 100,
         };
 

--- a/crates/svm-runtime-c-api/src/testing/receipt/exec_app.rs
+++ b/crates/svm-runtime-c-api/src/testing/receipt/exec_app.rs
@@ -1,6 +1,9 @@
 use svm_common::State;
 
-use svm_app::raw::{decode_func_args, decode_version, NibbleIter};
+use svm_app::{
+    raw::{decode_func_args, decode_version, NibbleIter},
+    types::WasmValue,
+};
 
 use super::helpers;
 
@@ -13,7 +16,7 @@ pub enum ClientExecReceipt {
         new_state: State,
 
         /// The values returns by the invoked app as a string
-        func_returns: String,
+        func_returns: Vec<WasmValue>,
 
         /// The gas used during the transaction
         gas_used: u64,
@@ -45,13 +48,13 @@ pub fn decode_exec_receipt(bytes: &[u8]) -> ClientExecReceipt {
         1 => {
             // success
             let new_state = helpers::decode_state(&mut iter);
-            let returns = decode_func_args(&mut iter).unwrap();
+            let func_returns = decode_func_args(&mut iter).unwrap();
             let gas_used = helpers::decode_gas_used(&mut iter);
 
             ClientExecReceipt::Success {
                 new_state,
                 gas_used,
-                func_returns: helpers::wasm_values_str(&returns[..]),
+                func_returns,
             }
         }
         _ => unreachable!(),

--- a/crates/svm-runtime-c-api/src/testing/receipt/helpers.rs
+++ b/crates/svm-runtime-c-api/src/testing/receipt/helpers.rs
@@ -1,7 +1,4 @@
-use svm_app::{
-    raw::{self, Field, Nibble, NibbleIter},
-    types::WasmValue,
-};
+use svm_app::raw::{self, Field, Nibble, NibbleIter};
 use svm_common::{Address, State};
 
 pub(crate) fn decode_is_success(iter: &mut NibbleIter) -> u8 {
@@ -30,17 +27,4 @@ pub(crate) fn decode_address(iter: &mut NibbleIter) -> Address {
 
 pub(crate) fn decode_gas_used(iter: &mut NibbleIter) -> u64 {
     raw::decode_gas_used(iter).unwrap()
-}
-
-pub(crate) fn wasm_values_str(values: &[WasmValue]) -> String {
-    let mut buf = String::new();
-
-    for (i, v) in values.iter().enumerate() {
-        if i != 0 {
-            buf.push_str(", ");
-        }
-        buf.push_str(&format!("{:?}", v));
-    }
-
-    buf
 }

--- a/crates/svm-runtime-c-api/src/testing/receipt/spawn_app.rs
+++ b/crates/svm-runtime-c-api/src/testing/receipt/spawn_app.rs
@@ -1,8 +1,7 @@
 use svm_app::{
     raw::{decode_func_args, decode_version, NibbleIter},
-    types::AppAddr,
+    types::{AppAddr, WasmValue},
 };
-
 use svm_common::State;
 
 use super::helpers;
@@ -19,7 +18,7 @@ pub enum ClientAppReceipt {
         init_state: State,
 
         /// The values returned by the App's ctor, concatenated as a string
-        ctor_returns: String,
+        ctor_returns: Vec<WasmValue>,
 
         /// The gas used during the transaction
         gas_used: u64,
@@ -59,7 +58,7 @@ pub fn decode_app_receipt(bytes: &[u8]) -> ClientAppReceipt {
                 addr: addr.into(),
                 init_state,
                 gas_used,
-                ctor_returns: helpers::wasm_values_str(&ctor_returns[..]),
+                ctor_returns,
             }
         }
         _ => unreachable!(),

--- a/crates/svm-runtime-c-api/tests/api_tests.rs
+++ b/crates/svm-runtime-c-api/tests/api_tests.rs
@@ -194,7 +194,6 @@ unsafe fn test_svm_runtime() {
     let mut kv = std::ptr::null_mut();
     let mut runtime = std::ptr::null_mut();
     let imports = create_imports();
-    let dry_run = false;
     let mut error = svm_byte_array::default();
 
     let res = api::svm_memory_kv_create(&mut kv);
@@ -233,7 +232,6 @@ unsafe fn test_svm_runtime() {
         host_ctx,
         gas_metering,
         gas_limit,
-        dry_run,
         &mut error,
     );
     assert!(res.is_ok());
@@ -273,7 +271,6 @@ unsafe fn test_svm_runtime() {
         host_ctx,
         gas_metering,
         gas_limit,
-        dry_run,
         &mut error,
     );
     assert!(res.is_ok());
@@ -316,7 +313,6 @@ unsafe fn test_svm_runtime() {
     };
 
     let mut exec_receipt = svm_byte_array::default();
-    let dry_run = false;
 
     let res = api::svm_exec_app(
         &mut exec_receipt,
@@ -326,7 +322,6 @@ unsafe fn test_svm_runtime() {
         host_ctx,
         gas_metering,
         gas_limit,
-        dry_run,
         &mut error,
     );
     assert!(res.is_ok());

--- a/crates/svm-runtime/src/runtime/runtime.rs
+++ b/crates/svm-runtime/src/runtime/runtime.rs
@@ -35,7 +35,6 @@ pub trait Runtime {
         author: &AuthorAddr,
         host_ctx: HostCtx,
         gas_limit: MaybeGas,
-        dry_run: bool,
     ) -> TemplateReceipt;
 
     /// Spawn a new app out of an existing app-template.
@@ -45,7 +44,6 @@ pub trait Runtime {
         creator: &CreatorAddr,
         host_ctx: HostCtx,
         gas_limit: MaybeGas,
-        dry_run: bool,
     ) -> SpawnAppReceipt;
 
     /// Executes an app-transaction. Returns `ExecReceipt`.
@@ -63,6 +61,5 @@ pub trait Runtime {
         state: &State,
         host_ctx: HostCtx,
         gas_limit: MaybeGas,
-        dry_run: bool,
     ) -> ExecReceipt;
 }


### PR DESCRIPTION
# Motivation
The original motivation we had `dry_run` flag was for enforcing non-changing state mode.
This turned to be a half-backed feature and it's actually not really a necessary one.