### PR TITLE
Fix multisig wallet WASM build

### DIFF
--- a/apps/src/wallet/Cargo.toml
+++ b/apps/src/wallet/Cargo.toml
@@ -8,8 +8,7 @@ publish = false
 [workspace]
 
 [lib]
-path = "src/lib.rs"
-# crate-type = ["cdylib"]
+crate-type = ["cdylib"]
 
 [profile.release]
 panic = "abort"

--- a/apps/src/wallet/build.sh
+++ b/apps/src/wallet/build.sh
@@ -1,7 +1,7 @@
 cargo +nightly build --target wasm32-unknown-unknown --release
 cp target/wasm32-unknown-unknown/release/*.wasm ../../../apps/wasm
 
-# compress the wasm artifact
+# optimize the wasm artifact in order to reduce size
 pushd ../../wasm
 wasm2wat wallet.wasm > wallet.wast
 rm wallet.wasm

--- a/apps/src/wallet/build.sh
+++ b/apps/src/wallet/build.sh
@@ -1,5 +1,7 @@
 cargo +nightly build --target wasm32-unknown-unknown --release
 cp target/wasm32-unknown-unknown/release/*.wasm ../../../apps/wasm
+
+# compress the wasm artifact
 pushd ../../wasm
 wasm2wat wallet.wasm > wallet.wast
 rm wallet.wasm


### PR DESCRIPTION
The compiler must produce a dynamic system library (`cdylib`).