### PR TITLE
Import func sig clones data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,9 +83,9 @@ dependencies = [
 
 [[package]]
 name = "bit-vec"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4523a10839ffae575fb08aa3423026c8cb4687eef43952afb956229d4f246f7"
+checksum = "5f0dc55f2d8a1a85650ac47858bb001b4c0dd73d79e3c455a842925e68d29cd3"
 
 [[package]]
 name = "bitflags"
@@ -95,9 +95,9 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "blake3"
-version = "0.2.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c58fbca3e5be3b7a3c24a5ec6976a6a464490528e8fee92896fe4ee2a40b10fb"
+checksum = "68df31bdf2bbb567e5adf8f21ac125dc0e897b1381e7b841f181521f06fc3134"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -133,9 +133,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.50"
+version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd"
+checksum = "404b1fe4f65288577753b17e3b36a04596ee784493ec249bf81c7f2d2acd751c"
 dependencies = [
  "jobserver",
 ]
@@ -157,9 +157,9 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "clang-sys"
-version = "0.29.2"
+version = "0.29.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f92986241798376849e1a007827041fed9bb36195822c2049d18e174420e0534"
+checksum = "fe6837df1d5cba2397b835c8530f51723267e16abbf83892e9e5af4f0e5dd10a"
 dependencies = [
  "glob 0.3.0",
  "libc",
@@ -168,9 +168,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.33.0"
+version = "2.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
+checksum = "bdfa80d47f954d53a35a64987ca1422f495b8d6483c0fe9f7117b36c2a792129"
 dependencies = [
  "ansi_term",
  "atty",
@@ -192,9 +192,9 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.42"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fb25b677f8bf1eb325017cb6bb8452f87969db0fedb4f757b297bee78a7c62"
+checksum = "49f97562167906afc51aa3fd7e6c83c10a5c96d33bd18f98a4c06a1413134caa"
 dependencies = [
  "cc",
 ]
@@ -276,9 +276,9 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a071601ed01b988f896ab14b95e67335d1eeb50190932a1320f7fe3cadc84e"
+checksum = "b480f641ccf0faf324e20c1d3e53d81b7484c698b42ea677f6907ae4db195371"
 dependencies = [
  "errno-dragonfly",
  "libc",
@@ -344,9 +344,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.8"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1010591b26bbfe835e9faeabeb11866061cc7dcebffd56ad7d0942d0e61aefd8"
+checksum = "91780f809e750b0a89f5544be56617ff6b1227ee485bcb06ebe10cdf89bd3b71"
 dependencies = [
  "libc",
 ]
@@ -405,9 +405,9 @@ checksum = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 
 [[package]]
 name = "libc"
-version = "0.2.68"
+version = "0.2.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea0c0405123bba743ee3f91f49b1c7cfb684eef0da0a50110f758ccf24cdff0"
+checksum = "3baa92041a6fec78c687fa0cc2b3fae8884f743d672cf551bed1d6dac6988d0f"
 
 [[package]]
 name = "libloading"
@@ -421,9 +421,9 @@ dependencies = [
 
 [[package]]
 name = "librocksdb-sys"
-version = "6.6.4"
+version = "6.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3b727e2dd20ec2fb7ed93f23d9fd5328a0871185485ebdaff007b47d3e27e4"
+checksum = "883213ae3d09bfc3d104aefe94b25ebb183b6f4d3a515b23b14817e1f4854005"
 dependencies = [
  "bindgen",
  "cc",
@@ -433,9 +433,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79b2de95ecb4691949fea4716ca53cdbcfccb2c612e19644a8bad05edcf9f47b"
+checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
 dependencies = [
  "scopeguard",
 ]
@@ -454,12 +454,6 @@ name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
-
-[[package]]
-name = "maybe-uninit"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "memchr"
@@ -527,9 +521,9 @@ checksum = "1e39faaa292a687ea15120b1ac31899b13586446521df6c149e46f1584671e0f"
 
 [[package]]
 name = "parking_lot"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e98c49ab0b7ce5b222f2cc9193fc4efe11c6d0bd4f648e374684a6857b1cfc"
+checksum = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -537,15 +531,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7582838484df45743c8434fbff785e8edf260c28748353d44bc0da32e0ceabf1"
+checksum = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
 dependencies = [
  "cfg-if",
  "cloudabi",
  "libc",
  "redox_syscall",
- "smallvec 1.2.0",
+ "smallvec",
  "winapi",
 ]
 
@@ -557,15 +551,15 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.6"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
+checksum = "237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.9"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c09721c6781493a2a492a96b5a5bf19b65917fe6728884e7c44dd0c60ca3435"
+checksum = "53f5ffe53a6b28e37c9c1ce74893477864d64f74778a93a4beb43c8fa167f639"
 dependencies = [
  "unicode-xid",
 ]
@@ -578,9 +572,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.3"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
+checksum = "42934bc9c8ab0d3b273a16d8551c8f0fcff46be73276ca083ec2414c15c4ba5e"
 dependencies = [
  "proc-macro2",
 ]
@@ -634,9 +628,9 @@ checksum = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 
 [[package]]
 name = "regex"
-version = "1.3.6"
+version = "1.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6946991529684867e47d86474e3a6d0c0ab9b82d5821e314b1ede31fa3a4b3"
+checksum = "a6020f034922e3194c711b82a627453881bc4682166cabb07134a10c26ba7692"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -686,9 +680,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "535622e6be132bccd223f4bb2b8ac8d53cda3c7a6394944d3b2b33fb974f9d76"
+checksum = "ed3d612bc64430efeb3f7ee6ef26d590dce0c43249217bddc62112540c7941e1"
 
 [[package]]
 name = "scopeguard"
@@ -713,9 +707,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.105"
+version = "1.0.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e707fbbf255b8fc8c3b99abb91e7257a622caeb20a9818cbadbeeede4e0932ff"
+checksum = "99e7b308464d16b56eba9964e4972a3eee817760ab60d88c3f86e1fecb08204c"
 dependencies = [
  "serde_derive",
 ]
@@ -732,18 +726,18 @@ dependencies = [
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325a073952621257820e7a3469f55ba4726d8b28657e7e36653d1c36dc2c84ae"
+checksum = "3bf487fbf5c6239d7ea2ff8b10cb6b811cd4b5080d1c2aeed1dec18753c06e10"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.105"
+version = "1.0.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac5d00fc561ba2724df6758a17de23df5914f20e41cb00f94d5b7ae42fffaff8"
+checksum = "818fbf6bfa9a42d3bfcaca148547aa00c7b915bec71d1757aa2d44ca68771984"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -752,9 +746,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.51"
+version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da07b57ee2623368351e9a0488bb0b261322a15a6e0ae53e243cbdc0f4208da9"
+checksum = "993948e75b189211a9b31a7528f950c6adc21f9720b6438ff80a7fa2f864cea2"
 dependencies = [
  "itoa",
  "ryu",
@@ -769,18 +763,9 @@ checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 
 [[package]]
 name = "smallvec"
-version = "0.6.13"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
-dependencies = [
- "maybe-uninit",
-]
-
-[[package]]
-name = "smallvec"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c2fb2ec9bcd216a5b0d0ccf31ab17b5ed1d627960edff65bbe95d3ce221cefc"
+checksum = "c7cb5678e1615754284ec264d9bb5b4c27d2018577fd90ac0ceb578591ed5ee4"
 
 [[package]]
 name = "stable_deref_trait"
@@ -963,9 +948,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.17"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0df0eb663f387145cab623dea85b09c2c5b4b0aef44e945d928e682fce71bb03"
+checksum = "1425de3c33b0941002740a420b1a906a350b88d08b82b2c8a01035a3f9447bac"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -974,9 +959,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f4c118a7a38378f305a9e111fcb2f7f838c0be324bfb31a77ea04f7f6e684b4"
+checksum = "ab0e7238dcc7b40a7be719a25365910f6807bd864f4cce6b2e6b873658e2b19d"
 
 [[package]]
 name = "tempfile"
@@ -1039,9 +1024,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.11.2"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9"
+checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
 
 [[package]]
 name = "unicode-width"
@@ -1057,9 +1042,9 @@ checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 
 [[package]]
 name = "vec_map"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
@@ -1103,17 +1088,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
+name = "wasmer"
+version = "0.17.0"
+source = "git+https://github.com/spacemeshos/wasmer?branch=develop#0575a7ed3f8742c3842afbc455072d957af7f6ce"
+dependencies = [
+ "serde",
+ "wasmer-runtime-core",
+ "wasmer-singlepass-backend",
+]
+
+[[package]]
 name = "wasmer-middleware-common"
-version = "0.16.2"
-source = "git+https://github.com/spacemeshos/wasmer?branch=develop#704c34283f66aff8a07a58d30462d7401e39843a"
+version = "0.17.0"
+source = "git+https://github.com/spacemeshos/wasmer?branch=develop#0575a7ed3f8742c3842afbc455072d957af7f6ce"
 dependencies = [
  "wasmer-runtime-core",
 ]
 
 [[package]]
 name = "wasmer-runtime"
-version = "0.16.2"
-source = "git+https://github.com/spacemeshos/wasmer?branch=develop#704c34283f66aff8a07a58d30462d7401e39843a"
+version = "0.17.0"
+source = "git+https://github.com/spacemeshos/wasmer?branch=develop#0575a7ed3f8742c3842afbc455072d957af7f6ce"
 dependencies = [
  "lazy_static",
  "memmap",
@@ -1125,19 +1120,19 @@ dependencies = [
 
 [[package]]
 name = "wasmer-runtime-c-api"
-version = "0.16.2"
-source = "git+https://github.com/spacemeshos/wasmer?branch=develop#704c34283f66aff8a07a58d30462d7401e39843a"
+version = "0.17.0"
+source = "git+https://github.com/spacemeshos/wasmer?branch=develop#0575a7ed3f8742c3842afbc455072d957af7f6ce"
 dependencies = [
  "cbindgen",
  "libc",
- "wasmer-runtime",
+ "wasmer",
  "wasmer-runtime-core",
 ]
 
 [[package]]
 name = "wasmer-runtime-core"
-version = "0.16.2"
-source = "git+https://github.com/spacemeshos/wasmer?branch=develop#704c34283f66aff8a07a58d30462d7401e39843a"
+version = "0.17.0"
+source = "git+https://github.com/spacemeshos/wasmer?branch=develop#0575a7ed3f8742c3842afbc455072d957af7f6ce"
 dependencies = [
  "bincode",
  "blake3",
@@ -1156,7 +1151,7 @@ dependencies = [
  "serde-bench",
  "serde_bytes",
  "serde_derive",
- "smallvec 0.6.13",
+ "smallvec",
  "target-lexicon",
  "wasmparser 0.51.4",
  "winapi",
@@ -1164,8 +1159,8 @@ dependencies = [
 
 [[package]]
 name = "wasmer-singlepass-backend"
-version = "0.16.2"
-source = "git+https://github.com/spacemeshos/wasmer?branch=develop#704c34283f66aff8a07a58d30462d7401e39843a"
+version = "0.17.0"
+source = "git+https://github.com/spacemeshos/wasmer?branch=develop#0575a7ed3f8742c3842afbc455072d957af7f6ce"
 dependencies = [
  "bincode",
  "byteorder",
@@ -1176,7 +1171,7 @@ dependencies = [
  "nix",
  "serde",
  "serde_derive",
- "smallvec 0.6.13",
+ "smallvec",
  "wasmer-runtime-core",
 ]
 
@@ -1219,9 +1214,9 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ccfbf554c6ad11084fb7517daca16cfdcaccbdadba4fc336f032a8b12c2ad80"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
  "winapi",
 ]

--- a/crates/svm-runtime-c-api/src/api.rs
+++ b/crates/svm-runtime-c-api/src/api.rs
@@ -5,16 +5,17 @@ use log::{debug, error};
 use svm_app::{
     default::DefaultSerializerTypes,
     testing::{AppTxBuilder, DeployAppTemplateBuilder, SpawnAppBuilder},
-    types::{HostCtx, WasmValue},
+    types::{HostCtx, WasmType, WasmValue},
 };
 use svm_common::{Address, State};
 use svm_runtime::{ctx::SvmCtx, gas::DefaultGasEstimator};
 
 use crate::{
-    helpers, raw_error, raw_io_error, raw_utf8_error, raw_validate_error,
+    helpers,
+    import::{Import, ImportFunc, ImportFuncSig, ImportKind, ImportValue},
+    raw_error, raw_io_error, raw_utf8_error, raw_validate_error,
     receipt::{encode_app_receipt, encode_exec_receipt, encode_template_receipt},
-    svm_byte_array, svm_import_func_sig_t, svm_import_func_t, svm_import_kind, svm_import_t,
-    svm_import_value, svm_result_t,
+    svm_byte_array, svm_result_t,
     testing::{self, ClientAppReceipt, ClientExecReceipt, ClientTemplateReceipt},
     RuntimePtr,
 };
@@ -191,7 +192,7 @@ pub unsafe extern "C" fn svm_validate_tx(
 #[must_use]
 #[no_mangle]
 pub unsafe extern "C" fn svm_imports_alloc(imports: *mut *mut c_void, count: u32) -> svm_result_t {
-    let vec: Vec<svm_import_t> = Vec::with_capacity(count as usize);
+    let vec: Vec<Import> = Vec::with_capacity(count as usize);
 
     *imports = svm_common::into_raw_mut(vec);
 
@@ -245,7 +246,7 @@ pub unsafe extern "C" fn svm_import_func_build(
     returns: svm_byte_array,
     error: *mut svm_byte_array,
 ) -> svm_result_t {
-    let imports = &mut *(imports as *mut Vec<svm_import_t>);
+    let imports = &mut *(imports as *mut Vec<Import>);
 
     assert!(imports.len() < imports.capacity());
 
@@ -257,11 +258,23 @@ pub unsafe extern "C" fn svm_import_func_build(
         return svm_result_t::SVM_FAILURE;
     }
 
-    let func = svm_import_func_t {
+    let params: Result<Vec<WasmType>, io::Error> = Vec::try_from(params);
+    if let Err(e) = params {
+        raw_io_error(e, error);
+        return svm_result_t::SVM_FAILURE;
+    }
+
+    let returns: Result<Vec<WasmType>, io::Error> = Vec::try_from(returns);
+    if let Err(e) = returns {
+        raw_io_error(e, error);
+        return svm_result_t::SVM_FAILURE;
+    }
+
+    let func = ImportFunc {
         func: func.unwrap(),
-        sig: svm_import_func_sig_t {
-            params: params,
-            returns: returns,
+        sig: ImportFuncSig {
+            params: params.unwrap(),
+            returns: returns.unwrap(),
         },
     };
 
@@ -277,11 +290,11 @@ pub unsafe extern "C" fn svm_import_func_build(
         return svm_result_t::SVM_FAILURE;
     }
 
-    let import = svm_import_t {
+    let import = Import {
         module_name: module_name.unwrap(),
         import_name: import_name.unwrap(),
-        kind: svm_import_kind::SVM_FUNCTION,
-        value: svm_import_value::Func(func),
+        kind: ImportKind::Function,
+        value: ImportValue::Func(func),
     };
 
     imports.push(import);
@@ -755,7 +768,7 @@ pub unsafe extern "C" fn svm_runtime_destroy(runtime: *mut c_void) {
 #[must_use]
 #[no_mangle]
 pub unsafe extern "C" fn svm_imports_destroy(imports: *const c_void) {
-    let _ = Box::from_raw(imports as *mut Vec<svm_import_t>);
+    let _ = Box::from_raw(imports as *mut Vec<Import>);
 }
 
 /// Frees `svm_byte_array`

--- a/crates/svm-runtime-c-api/src/helpers.rs
+++ b/crates/svm-runtime-c-api/src/helpers.rs
@@ -1,6 +1,9 @@
 use std::ffi::c_void;
 
-use crate::{svm_import_kind, svm_import_t, RuntimePtr};
+use crate::{
+    import::{Import, ImportKind},
+    RuntimePtr,
+};
 
 use svm_runtime::Runtime;
 
@@ -31,11 +34,11 @@ pub unsafe fn cast_imports_to_wasmer_imports(
 
     let mut res: Vec<(String, String, Export)> = Vec::new();
 
-    let imports = &*(imports as *const Vec<svm_import_t>);
+    let imports = &*(imports as *const Vec<Import>);
 
     for import in imports.iter() {
         let wasmer_import = match import.kind {
-            svm_import_kind::SVM_FUNCTION => crate::wasmer::to_wasmer_import_func(import),
+            ImportKind::Function => crate::wasmer::to_wasmer_import_func(import),
         };
 
         let module_name = import.module_name.clone();

--- a/crates/svm-runtime-c-api/src/import.rs
+++ b/crates/svm-runtime-c-api/src/import.rs
@@ -1,44 +1,42 @@
 use std::{ffi::c_void, ptr::NonNull};
 
+use svm_app::types::WasmType;
+
 use crate::svm_byte_array;
 
 /// Represents an `Import` kind
-#[allow(non_camel_case_types)]
-pub enum svm_import_kind {
+pub enum ImportKind {
     #[doc(hidden)]
-    SVM_FUNCTION,
+    Function,
 }
 
 /// FFI representation for import function signature
-#[allow(non_camel_case_types)]
-pub struct svm_import_func_sig_t {
+pub struct ImportFuncSig {
     /// Function params types
-    pub params: svm_byte_array,
+    pub params: Vec<WasmType>,
 
     /// Function returns types
-    pub returns: svm_byte_array,
+    pub returns: Vec<WasmType>,
 }
 
 /// FFI representation for import function
-#[allow(non_camel_case_types)]
-pub struct svm_import_func_t {
+pub struct ImportFunc {
     /// Raw pointer to function
     pub func: NonNull<c_void>,
 
     /// Function signature
-    pub sig: svm_import_func_sig_t,
+    pub sig: ImportFuncSig,
 }
 
 #[doc(hidden)]
-#[allow(non_camel_case_types)]
-pub enum svm_import_value {
+pub enum ImportValue {
     #[doc(hidden)]
-    Func(svm_import_func_t),
+    Func(ImportFunc),
 }
 
 /// An import declaration
 #[allow(non_camel_case_types)]
-pub struct svm_import_t {
+pub struct Import {
     /// Module name string as `svm_byte_array`
     pub module_name: String,
 
@@ -46,8 +44,8 @@ pub struct svm_import_t {
     pub import_name: String,
 
     /// Import type (for example: function import)
-    pub kind: svm_import_kind,
+    pub kind: ImportKind,
 
     /// Import value (for example: a pointer to function)
-    pub value: svm_import_value,
+    pub value: ImportValue,
 }

--- a/crates/svm-runtime-c-api/src/lib.rs
+++ b/crates/svm-runtime-c-api/src/lib.rs
@@ -37,9 +37,6 @@ pub use api::{
     svm_validate_tx,
 };
 pub use byte_array::svm_byte_array;
-pub use import::{
-    svm_import_func_sig_t, svm_import_func_t, svm_import_kind, svm_import_t, svm_import_value,
-};
 pub use result::svm_result_t;
 
 mod runtime_ptr;

--- a/crates/svm-runtime/src/runtime/default.rs
+++ b/crates/svm-runtime/src/runtime/default.rs
@@ -441,7 +441,7 @@ where
             panic!()
         }
 
-        instance.dyn_func(&func_name.unwrap()).or_else(|_e| {
+        instance.exports.get(&func_name.unwrap()).or_else(|_e| {
             error!("Exported function: `{}` not found", func_idx);
 
             Err(ExecAppError::FuncNotFound {

--- a/crates/svm-runtime/tests/vmcalls.rs
+++ b/crates/svm-runtime/tests/vmcalls.rs
@@ -75,7 +75,7 @@ fn vmcalls_mem_to_reg_copy() {
     let reg = instance_register(&instance, reg_bits, reg_idx);
     assert_eq!(vec![0; reg_size as usize], reg.view());
 
-    let func: Func<(u32, u32, u32, u32)> = instance.func("run").unwrap();
+    let func: Func<(u32, u32, u32, u32)> = instance.exports.get("run").unwrap();
     assert!(func.call(mem_offset, reg_bits, reg_idx, count).is_ok());
 
     // asserting register content is `10, 20, 30, 0, 0, ... 0`
@@ -114,7 +114,7 @@ fn vmcalls_reg_to_mem_copy() {
     assert_eq!(vec![0; count as usize], before);
 
     // copying register into memory
-    let func: Func<(u32, u32, u32, u32)> = instance.func("run").unwrap();
+    let func: Func<(u32, u32, u32, u32)> = instance.exports.get("run").unwrap();
     assert!(func.call(reg_bits, reg_idx, mem_offset, count).is_ok());
 
     let after = testing::instance_memory_view(&instance, mem_offset, count);
@@ -152,7 +152,7 @@ fn vmcalls_storage_read_an_empty_page_slice_to_reg() {
     let reg = instance_register(&instance, reg_bits, reg_idx);
     reg.set(&vec![0xFF; reg_size as usize]);
 
-    let func: Func<(u32, u32, u32, u32, u32)> = instance.func("run").unwrap();
+    let func: Func<(u32, u32, u32, u32, u32)> = instance.exports.get("run").unwrap();
     assert!(func
         .call(page_idx, page_offset, reg_bits, reg_idx, count)
         .is_ok());
@@ -202,7 +202,7 @@ fn vmcalls_storage_read_non_empty_page_slice_to_reg() {
     reg.set(&vec![0xFF; reg_size as usize]);
 
     // we copy slice into register
-    let func: Func<(u32, u32, u32, u32, u32)> = instance.func("run").unwrap();
+    let func: Func<(u32, u32, u32, u32, u32)> = instance.exports.get("run").unwrap();
 
     assert!(func
         .call(page_idx, page_offset, reg_bits, reg_idx, count)
@@ -243,7 +243,7 @@ fn vmcalls_storage_read_an_empty_page_slice_to_mem() {
     assert_eq!(vec![0xFF; count as usize], before);
 
     // we copy page-slice into memory `#0`
-    let func: Func<(u32, u32, u32, u32)> = instance.func("run").unwrap();
+    let func: Func<(u32, u32, u32, u32)> = instance.exports.get("run").unwrap();
     assert!(func.call(page_idx, page_offset, mem_offset, count).is_ok());
 
     let after = testing::instance_memory_view(&instance, mem_offset, count);
@@ -283,7 +283,7 @@ fn vmcalls_storage_read_non_empty_page_slice_to_mem() {
     storage.write_page_slice(&layout, &data[..]);
 
     // we copy slice (page `1`, cells: `100..103`) into memory #0, starting from address `200`
-    let func: Func<(u32, u32, u32, u32)> = instance.func("run").unwrap();
+    let func: Func<(u32, u32, u32, u32)> = instance.exports.get("run").unwrap();
     assert!(func.call(page_idx, page_offset, mem_offset, count).is_ok());
 
     let after = testing::instance_memory_view(&instance, mem_offset, count);
@@ -328,7 +328,7 @@ fn vmcalls_storage_write_from_mem() {
     assert_eq!(vec![0; count as usize], before);
 
     // we copy memory cells `200..`203` into storage (`page 1`, cells: `100..103`)
-    let func: Func<(u32, u32, u32, u32)> = instance.func("run").unwrap();
+    let func: Func<(u32, u32, u32, u32)> = instance.exports.get("run").unwrap();
     assert!(func.call(mem_offset, page_idx, page_offset, count).is_ok());
 
     let after = storage.read_page_slice(&layout);
@@ -376,7 +376,7 @@ fn vmcalls_storage_write_from_reg() {
     assert_eq!(vec![0; count as usize], before);
 
     // we copy register first into storage
-    let func: Func<(u32, u32, u32, u32, u32)> = instance.func("run").unwrap();
+    let func: Func<(u32, u32, u32, u32, u32)> = instance.exports.get("run").unwrap();
 
     assert!(func
         .call(reg_bits, reg_idx, page_idx, page_offset, count)
@@ -413,7 +413,7 @@ fn vmcalls_reg_push() {
     reg.set(&data[..]);
 
     // will call `reg_push` on input register
-    let func: Func<(u32, u32)> = instance.func("run").unwrap();
+    let func: Func<(u32, u32)> = instance.exports.get("run").unwrap();
     assert!(func.call(reg_bits, reg_idx).is_ok());
 
     let reg = instance_register(&instance, reg_bits, reg_idx);
@@ -449,7 +449,7 @@ fn vmcalls_reg_pop() {
     reg.push();
 
     // will call `reg_pop` on input register
-    let func: Func<(u32, u32)> = instance.func("run").unwrap();
+    let func: Func<(u32, u32)> = instance.exports.get("run").unwrap();
     assert!(func.call(reg_bits, reg_idx).is_ok());
 
     // if `instance` triggered `reg_pop` we need to be back to where we were before calling `push`
@@ -485,21 +485,21 @@ fn vmcalls_reg_set_number() {
     );
 
     // run i32 Big-Endian
-    let func: Func<(u32, u32, u32)> = instance.func("run_i32_be").unwrap();
+    let func: Func<(u32, u32, u32)> = instance.exports.get("run_i32_be").unwrap();
     assert!(func.call(reg_bits, reg_idx, n).is_ok());
 
     let reg = instance_register(&instance, reg_bits, reg_idx);
     assert_eq!(&[0x10, 0x20, 0x30, 0x40], &reg.view()[0..4]);
 
     // run i32 Little-Endian
-    let func: Func<(u32, u32, u32)> = instance.func("run_i32_le").unwrap();
+    let func: Func<(u32, u32, u32)> = instance.exports.get("run_i32_le").unwrap();
     assert!(func.call(reg_bits, reg_idx, n).is_ok());
 
     let reg = instance_register(&instance, reg_bits, reg_idx);
     assert_eq!(&[0x40, 0x30, 0x20, 0x10], &reg.view()[0..4]);
 
     // run i64 Big-Endian
-    let func: Func<(u32, u32, u64)> = instance.func("run_i64_be").unwrap();
+    let func: Func<(u32, u32, u64)> = instance.exports.get("run_i64_be").unwrap();
     assert!(func.call(reg_bits, reg_idx, m).is_ok());
 
     let reg = instance_register(&instance, reg_bits, reg_idx);
@@ -509,7 +509,7 @@ fn vmcalls_reg_set_number() {
     );
 
     // run i64 Little-Endian
-    let func: Func<(u32, u32, u64)> = instance.func("run_i64_le").unwrap();
+    let func: Func<(u32, u32, u64)> = instance.exports.get("run_i64_le").unwrap();
     assert!(func.call(reg_bits, reg_idx, m).is_ok());
 
     let reg = instance_register(&instance, reg_bits, reg_idx);
@@ -544,7 +544,7 @@ fn vmcalls_reg_cmp() {
     reg1.set(&[0x10, 0x20, 0x30]);
     reg2.set(&[0x10, 0x20, 0x30]);
 
-    let func: Func<(u32, u32), i32> = instance.func("reg_128_cmp").unwrap();
+    let func: Func<(u32, u32), i32> = instance.exports.get("reg_128_cmp").unwrap();
     let rets = func.call(reg_idx1, reg_idx2);
     assert_eq!(Ok(0), rets);
 
@@ -552,7 +552,7 @@ fn vmcalls_reg_cmp() {
     reg1.set(&[0x10, 0x20, 0x40]);
     reg2.set(&[0x10, 0x20, 0x30]);
 
-    let func: Func<(u32, u32), i32> = instance.func("reg_128_cmp").unwrap();
+    let func: Func<(u32, u32), i32> = instance.exports.get("reg_128_cmp").unwrap();
     let rets = func.call(reg_idx1, reg_idx2);
     assert_eq!(Ok(-1), rets);
 
@@ -560,7 +560,7 @@ fn vmcalls_reg_cmp() {
     reg1.set(&[0x10, 0x20, 0x30]);
     reg2.set(&[0x10, 0x20, 0x40]);
 
-    let func: Func<(u32, u32), i32> = instance.func("reg_128_cmp").unwrap();
+    let func: Func<(u32, u32), i32> = instance.exports.get("reg_128_cmp").unwrap();
     let rets = func.call(reg_idx1, reg_idx2);
     assert_eq!(Ok(1), rets);
 }
@@ -596,7 +596,7 @@ fn vmcalls_host_ctx_read_into_reg() {
         maybe_gas,
     );
 
-    let func: Func<(u32, u32, u32)> = instance.func("run").unwrap();
+    let func: Func<(u32, u32, u32)> = instance.exports.get("run").unwrap();
 
     // copying field #2 (content=`[10, 20]`) into register
     assert!(func.call(field_idx, reg_bits, reg_idx).is_ok());
@@ -630,14 +630,14 @@ fn vmcalls_buffer_copy_to_storage() {
         testing::instantiate(&import_object, include_str!("wasm/buffer.wast"), maybe_gas);
 
     // maybe_create buffer
-    let func: Func<u32> = instance.func("create").unwrap();
+    let func: Func<u32> = instance.exports.get("create").unwrap();
     assert!(func.call(buf_id).is_ok());
 
     let buf = instance_buffer(&instance, buf_id).unwrap();
     buf.write(&data);
 
     // copy buf slice into page
-    let func: Func<(u32, u32, u32, u32, u32)> = instance.func("copy").unwrap();
+    let func: Func<(u32, u32, u32, u32, u32)> = instance.exports.get("copy").unwrap();
     assert!(func
         .call(buf_id, buf_offset, page_idx, page_offset, count)
         .is_ok());
@@ -645,7 +645,7 @@ fn vmcalls_buffer_copy_to_storage() {
     // killing buffer
     assert!(instance_buffer(&instance, buf_id).is_some());
 
-    let func: Func<u32> = instance.func("kill").unwrap();
+    let func: Func<u32> = instance.exports.get("kill").unwrap();
     assert!(func.call(buf_id).is_ok());
 
     assert!(instance_buffer(&instance, buf_id).is_none());
@@ -670,7 +670,7 @@ macro_rules! assert_int_slice {
 
 macro_rules! assert_i32_field {
     ($expected:expr, $instance:expr, $field_idx:expr, $endianness:expr) => {{
-        let func: Func<(u32, u32), u32> = $instance.func("read_i32").unwrap();
+        let func: Func<(u32, u32), u32> = $instance.exports.get("read_i32").unwrap();
 
         assert_eq!($expected, func.call($field_idx, $endianness).unwrap());
     }};
@@ -678,7 +678,7 @@ macro_rules! assert_i32_field {
 
 macro_rules! assert_i64_field {
     ($expected:expr, $instance:expr, $field_idx:expr, $endianness:expr) => {{
-        let func: Func<(u32, u32), u64> = $instance.func("read_i64").unwrap();
+        let func: Func<(u32, u32), u64> = $instance.exports.get("read_i64").unwrap();
 
         assert_eq!($expected, func.call($field_idx, $endianness).unwrap());
     }};
@@ -729,12 +729,12 @@ macro_rules! test_storage_read_int {
 	let (page_idx, page_offset, count) = (slice.0, slice.1, slice.2.len() as u32);
 
 	if count <= 4 {
-	    let func: Func<(u32, u32, u32, u32), u32> = instance.func("read_i32").unwrap();
+	    let func: Func<(u32, u32, u32, u32), u32> = instance.exports.get("read_i32").unwrap();
 
 	    assert_int_slice!(expected as u32, func, page_idx, page_offset, count, $endianness);
 	}
 	else {
-	    let func: Func<(u32, u32, u32, u32), u64> = instance.func("read_i64").unwrap();
+	    let func: Func<(u32, u32, u32, u32), u64> = instance.exports.get("read_i64").unwrap();
 
 	    assert_int_slice!(expected, func, page_idx, page_offset, count, $endianness);
 	}
@@ -773,11 +773,11 @@ macro_rules! test_storage_write_int {
 	let (page_idx, page_offset, nbytes, n) = slices[$slice_idx];
 
 	if nbytes <= 4 {
-	    let func: Func<(u32, u32, u32, u32, u32)> = instance.func("write_i32").unwrap();
+	    let func: Func<(u32, u32, u32, u32, u32)> = instance.exports.get("write_i32").unwrap();
 	    assert!(func.call(page_idx, page_offset, n as u32, nbytes, $endianness).is_ok());
 	}
 	else {
-	    let func: Func<(u32, u32, u64, u32, u32)> = instance.func("write_i64").unwrap();
+	    let func: Func<(u32, u32, u64, u32, u32)> = instance.exports.get("write_i64").unwrap();
 	    assert!(func.call(page_idx, page_offset, n, nbytes, $endianness).is_ok());
 	}
 


### PR DESCRIPTION
# Motivation

We want the SVM import function struct to hold `Vec<WasmType>` and not `svm_byte_array`.
(within the `svm-runtime-c-api` crate).

By having the requested, the `go-svm` (or future similar clients) can pass the function signature's
`params` and `returns` and reclaim their memory right after. That will work since Rust will convert that data internally to a new `Vec<WasmType>` isolated from the raw input.

https://github.com/spacemeshos/svm/blob/2ef6696cd5ee0c1d5195af3d6c8f91fd559d6a11/crates/svm-runtime-c-api/src/api.rs#L239