### PR TITLE
`svm_byte_array` to `DataLayout`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,9 +192,9 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f97562167906afc51aa3fd7e6c83c10a5c96d33bd18f98a4c06a1413134caa"
+checksum = "0e56268c17a6248366d66d4a47a3381369d068cce8409bb1716ed77ea32163bb"
 dependencies = [
  "cc",
 ]
@@ -572,9 +572,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42934bc9c8ab0d3b273a16d8551c8f0fcff46be73276ca083ec2414c15c4ba5e"
+checksum = "54a21852a652ad6f610c9510194f398ff6f8692e334fd1145fed931f7fbe44ea"
 dependencies = [
  "proc-macro2",
 ]
@@ -801,6 +801,7 @@ dependencies = [
  "svm-compiler",
  "svm-gas",
  "svm-kv",
+ "svm-layout",
  "svm-runtime",
  "svm-runtime-c-api",
  "svm-storage",
@@ -834,7 +835,7 @@ dependencies = [
  "maplit",
  "svm-common",
  "svm-kv",
- "svm-storage2",
+ "svm-layout",
 ]
 
 [[package]]
@@ -846,7 +847,7 @@ dependencies = [
  "regex",
  "svm-app",
  "svm-common",
- "svm-storage2",
+ "svm-layout",
  "tempfile",
 ]
 
@@ -895,6 +896,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "svm-layout"
+version = "0.0.0"
+
+[[package]]
 name = "svm-runtime"
 version = "0.0.0"
 dependencies = [
@@ -907,6 +912,7 @@ dependencies = [
  "svm-compiler",
  "svm-gas",
  "svm-kv",
+ "svm-layout",
  "svm-storage",
  "svm-storage2",
  "wabt",
@@ -928,6 +934,7 @@ dependencies = [
  "svm-compiler",
  "svm-gas",
  "svm-kv",
+ "svm-layout",
  "svm-runtime",
  "svm-storage",
  "svm-storage2",
@@ -957,6 +964,7 @@ version = "0.0.0"
 dependencies = [
  "svm-common",
  "svm-kv",
+ "svm-layout",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ svm-gas = { path = "crates/svm-gas" }
 svm-abi = { path = "crates/svm-abi" }
 svm-app = { path = "crates/svm-app" }
 svm-storage = { path = "crates/svm-storage" }
+svm-layout = { path = "crates/svm-layout" }
 svm-storage2 = { path = "crates/svm-storage2" }
 svm-compiler = { path = "crates/svm-compiler" }
 svm-runtime = { path = "crates/svm-runtime" }
@@ -79,6 +80,8 @@ members = [
   "crates/svm-common",
   "crates/svm-kv",
   "crates/svm-storage",
+  "crates/svm-layout",
+  "crates/svm-storage2",
   "crates/svm-runtime",
   "crates/svm-compiler",
   "crates/svm-runtime-c-api",

--- a/crates/svm-app/Cargo.toml
+++ b/crates/svm-app/Cargo.toml
@@ -12,8 +12,8 @@ path = "../svm-common"
 [dependencies.svm-kv]
 path = "../svm-kv"
 
-[dependencies.svm-storage2]
-path = "../svm-storage2"
+[dependencies.svm-layout]
+path = "../svm-layout"
 
 [dependencies.byteorder]
 version = "1.3.2"

--- a/crates/svm-app/src/raw/template/serialize.rs
+++ b/crates/svm-app/src/raw/template/serialize.rs
@@ -6,7 +6,7 @@ use crate::{
     types::{AppTemplate, AuthorAddr},
 };
 
-use svm_storage2::layout::DataLayout;
+use svm_layout::DataLayout;
 
 /// `AppTemplate` default Serializer
 pub struct DefaultAppTemplateSerializer;

--- a/crates/svm-app/src/raw/template/wire.rs
+++ b/crates/svm-app/src/raw/template/wire.rs
@@ -3,7 +3,7 @@ use crate::{
     raw::{helpers, Field, NibbleIter, NibbleWriter},
     types::AppTemplate,
 };
-use svm_storage2::layout::{DataLayout, DataLayoutBuilder, VarId};
+use svm_layout::{DataLayout, DataLayoutBuilder, VarId};
 
 /// Encodes a raw Deploy-Template.
 pub fn encode_deploy_template(template: &AppTemplate, w: &mut NibbleWriter) {

--- a/crates/svm-app/src/testing/template_builder.rs
+++ b/crates/svm-app/src/testing/template_builder.rs
@@ -3,7 +3,7 @@ use crate::{
     types::AppTemplate,
 };
 
-use svm_storage2::layout::DataLayout;
+use svm_layout::DataLayout;
 
 /// Builds a raw representation for `deploy-template`
 /// Should be used for testing only.

--- a/crates/svm-app/src/types/template.rs
+++ b/crates/svm-app/src/types/template.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use svm_storage2::layout::DataLayout;
+use svm_layout::DataLayout;
 
 /// An in-memory representation of an app-template.
 #[allow(missing_docs)]

--- a/crates/svm-cli/Cargo.toml
+++ b/crates/svm-cli/Cargo.toml
@@ -12,8 +12,8 @@ path = "../svm-common"
 [dependencies.svm-app]
 path = "../svm-app"
 
-[dependencies.svm-storage2]
-path = "../svm-storage2"
+[dependencies.svm-layout]
+path = "../svm-layout"
 
 [dependencies]
 clap = "2.33.0"

--- a/crates/svm-cli/src/app_template.rs
+++ b/crates/svm-cli/src/app_template.rs
@@ -6,8 +6,7 @@ use svm_app::{
     raw::decode_deploy_template, raw::NibbleIter, testing::DeployAppTemplateBuilder,
     types::AppTemplate,
 };
-
-use svm_storage2::layout::DataLayout;
+use svm_layout::DataLayout;
 
 pub fn encode(
     version: u32,

--- a/crates/svm-layout/Cargo.toml
+++ b/crates/svm-layout/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "svm-storage2"
+name = "svm-layout"
 version = "0.0.0"
 authors = ["Yaron Wittenstein <yaron.wittenstein@gmail.com>"]
 license = "MIT"
@@ -10,11 +10,4 @@ homepage = "https://github.com/spacemeshos/svm"
 description = "Spacemesh Virtual Machine"
 publish = false
 
-[dependencies.svm-kv]
-path = "../svm-kv"
-
-[dependencies.svm-common]
-path = "../svm-common"
-
-[dependencies.svm-layout]
-path = "../svm-layout"
+[dependencies]

--- a/crates/svm-layout/src/builder.rs
+++ b/crates/svm-layout/src/builder.rs
@@ -1,4 +1,4 @@
-use super::DataLayout;
+use crate::layout::DataLayout;
 
 /// Specifies the fixed-sized variables of an application.
 pub struct DataLayoutBuilder {

--- a/crates/svm-layout/src/layout.rs
+++ b/crates/svm-layout/src/layout.rs
@@ -1,4 +1,4 @@
-use super::DataLayoutBuilder;
+use crate::builder::DataLayoutBuilder;
 
 /// Repersents a variable. an unsigned integer.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]

--- a/crates/svm-layout/src/lib.rs
+++ b/crates/svm-layout/src/lib.rs
@@ -1,0 +1,12 @@
+#![deny(missing_docs)]
+#![deny(unused)]
+#![deny(dead_code)]
+#![deny(unreachable_code)]
+
+//! This crate is responsible on representing an Application's storage variables data-layout.
+
+mod builder;
+mod layout;
+
+pub use builder::DataLayoutBuilder;
+pub use layout::{DataLayout, VarId};

--- a/crates/svm-runtime-c-api/Cargo.toml
+++ b/crates/svm-runtime-c-api/Cargo.toml
@@ -51,6 +51,9 @@ default-features = false
 path = "../svm-storage"
 features = ["svm_memory"]
 
+[dependencies.svm-layout]
+path = "../svm-layout"
+
 [dependencies.svm-storage2]
 path = "../svm-storage2"
 

--- a/crates/svm-runtime-c-api/src/layout.rs
+++ b/crates/svm-runtime-c-api/src/layout.rs
@@ -1,7 +1,7 @@
 use std::convert::{TryFrom, TryInto};
 use std::io::{self, ErrorKind};
 
-use byteorder::{BigEndian, ByteOrder, ReadBytesExt};
+use byteorder::{BigEndian, ByteOrder};
 
 use crate::svm_byte_array;
 
@@ -9,6 +9,15 @@ pub use svm_layout::DataLayout;
 
 ///
 /// Parsing raw `DataLayout` given as `svm_byte_array` into `DataLayout`.
+///
+/// Here is the raw reprentation of a `DataLayout`:
+///
+/// +-----------------------------------------------------------+
+/// | var #0 length (4 bytes) | . . . | var #N length (4 bytes) |
+/// +-----------------------------------------------------------+
+///
+/// Each variable length conumes exactly 4 bytes encoded in a Big-Endian order.
+/// Given that, the `length` of the `svm_byte_array` must be divisble by 4.
 ///
 /// # Example
 ///

--- a/crates/svm-runtime-c-api/src/layout.rs
+++ b/crates/svm-runtime-c-api/src/layout.rs
@@ -1,0 +1,59 @@
+use std::convert::{TryFrom, TryInto};
+use std::io::{self, ErrorKind};
+
+use byteorder::{BigEndian, ByteOrder, ReadBytesExt};
+
+use crate::svm_byte_array;
+
+pub use svm_layout::DataLayout;
+
+///
+/// Parsing raw `DataLayout` given as `svm_byte_array` into `DataLayout`.
+///
+/// # Example
+///
+/// ```
+/// use std::io;
+/// use std::convert::TryFrom;
+///
+/// use svm_layout::{VarId, DataLayout};
+/// use svm_runtime_c_api::svm_byte_array;
+///
+/// let data: Vec<u8> = vec![0, 0, 0, 10, 0, 0, 0, 20, 0, 0, 0, 30];
+/// let bytes: svm_byte_array = data.into();
+///
+/// let layout: Result<DataLayout, io::Error> = DataLayout::try_from(bytes);
+/// assert!(layout.is_ok());
+///
+/// let layout = layout.unwrap();
+///
+/// assert_eq!(layout.len(), 3);
+/// assert_eq!(layout.get_var(VarId(0)), (0,  10));
+/// assert_eq!(layout.get_var(VarId(1)), (10, 20));
+/// assert_eq!(layout.get_var(VarId(2)), (30, 30));
+/// ```
+///
+impl TryFrom<&svm_byte_array> for DataLayout {
+    type Error = io::Error;
+
+    fn try_from(bytes: &svm_byte_array) -> Result<Self, Self::Error> {
+        if bytes.length % 4 != 0 {
+            return Err(ErrorKind::InvalidInput.into());
+        }
+
+        let bytes: &[u8] = bytes.into();
+        let raw_layout: Vec<u32> = bytes.chunks(4).map(BigEndian::read_u32).collect();
+
+        let layout = DataLayout::from(&raw_layout[..]);
+        Ok(layout)
+    }
+}
+
+impl TryFrom<svm_byte_array> for DataLayout {
+    type Error = io::Error;
+
+    #[inline]
+    fn try_from(bytes: svm_byte_array) -> Result<Self, Self::Error> {
+        (&bytes).try_into()
+    }
+}

--- a/crates/svm-runtime-c-api/src/lib.rs
+++ b/crates/svm-runtime-c-api/src/lib.rs
@@ -1,7 +1,7 @@
-#![allow(missing_docs)]
-#![allow(unused)]
-#![allow(dead_code)]
-#![allow(unreachable_code)]
+#![deny(missing_docs)]
+#![deny(unused)]
+#![deny(dead_code)]
+#![deny(unreachable_code)]
 #![feature(vec_into_raw_parts)]
 
 //! This crate is responsible of providing [FFI](https://doc.rust-lang.org/nomicon/ffi.html) interface for the `SVM`.

--- a/crates/svm-runtime-c-api/src/lib.rs
+++ b/crates/svm-runtime-c-api/src/lib.rs
@@ -1,7 +1,7 @@
-#![deny(missing_docs)]
-#![deny(unused)]
-#![deny(dead_code)]
-#![deny(unreachable_code)]
+#![allow(missing_docs)]
+#![allow(unused)]
+#![allow(dead_code)]
+#![allow(unreachable_code)]
 #![feature(vec_into_raw_parts)]
 
 //! This crate is responsible of providing [FFI](https://doc.rust-lang.org/nomicon/ffi.html) interface for the `SVM`.
@@ -17,6 +17,7 @@ mod api;
 mod byte_array;
 mod error;
 mod import;
+mod layout;
 mod macros;
 mod receipt;
 mod result;

--- a/crates/svm-runtime-c-api/tests/api_tests.rs
+++ b/crates/svm-runtime-c-api/tests/api_tests.rs
@@ -9,9 +9,8 @@ use std::{collections::HashMap, ffi::c_void};
 
 use svm_app::types::{WasmType, WasmValue};
 use svm_common::Address;
+use svm_layout::DataLayout;
 use svm_runtime::register::Register;
-
-use svm_storage2::layout::DataLayout;
 
 #[derive(Debug)]
 struct Host {

--- a/crates/svm-runtime/Cargo.toml
+++ b/crates/svm-runtime/Cargo.toml
@@ -17,6 +17,9 @@ default-features = false
 path = "../svm-storage"
 features = ["default"]
 
+[dependencies.svm-layout]
+path = "../svm-layout"
+
 [dependencies.svm-storage2]
 path = "../svm-storage2"
 

--- a/crates/svm-runtime/src/settings.rs
+++ b/crates/svm-runtime/src/settings.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
-use svm_storage2::layout::DataLayout;
+
+use svm_layout::DataLayout;
 
 /// Holds settings for using the Runtime.
 #[derive(Debug, Clone)]

--- a/crates/svm-runtime/src/testing.rs
+++ b/crates/svm-runtime/src/testing.rs
@@ -18,10 +18,9 @@ use svm_app::{
 };
 use svm_common::{Address, State};
 use svm_kv::{memory::MemKVStore, traits::KVStore};
+use svm_layout::DataLayout;
 use svm_storage::AppStorage;
-use svm_storage2::{
-    app::AppKVStore, app::AppStorage as AppStorage2, kv::FakeKV, layout::DataLayout,
-};
+use svm_storage2::{app::AppKVStore, app::AppStorage as AppStorage2, kv::FakeKV};
 
 use wasmer_runtime_core::{export::Export, import::ImportObject, Instance, Module};
 

--- a/crates/svm-runtime/src/vmcalls/storage2.rs
+++ b/crates/svm-runtime/src/vmcalls/storage2.rs
@@ -3,7 +3,7 @@ use crate::{helpers, use_gas};
 use byteorder::{BigEndian, ByteOrder};
 use wasmer_runtime::Ctx as WasmerCtx;
 
-use svm_storage2::layout::VarId;
+use svm_layout::VarId;
 
 /// Returns the data stored by variable `var_id` as 64-bit integer.
 ///

--- a/crates/svm-runtime/tests/runtime.rs
+++ b/crates/svm-runtime/tests/runtime.rs
@@ -7,6 +7,7 @@ use svm_app::{
 };
 use svm_common::Address;
 use svm_gas::error::ProgramError;
+use svm_layout::DataLayout;
 use svm_runtime::{
     error::ValidateError,
     gas::MaybeGas,
@@ -16,7 +17,6 @@ use svm_runtime::{
     testing,
 };
 use svm_storage::page::{PageIndex, PageOffset, PageSliceLayout};
-use svm_storage2::layout::DataLayout;
 
 macro_rules! default_runtime {
     () => {{

--- a/crates/svm-runtime/tests/vmcalls.rs
+++ b/crates/svm-runtime/tests/vmcalls.rs
@@ -6,6 +6,7 @@ use wasmer_runtime::{func, imports, Func};
 
 use svm_app::types::HostCtx;
 use svm_common::{Address, State};
+use svm_layout::DataLayout;
 use svm_runtime::{
     gas::MaybeGas,
     helpers::{self, DataWrapper},
@@ -13,7 +14,6 @@ use svm_runtime::{
     vmcalls,
 };
 use svm_storage::page::{PageIndex, PageOffset, PageSliceLayout};
-use svm_storage2::layout::DataLayout;
 
 fn default_test_args() -> (
     Address,

--- a/crates/svm-runtime/tests/vmcalls2.rs
+++ b/crates/svm-runtime/tests/vmcalls2.rs
@@ -3,13 +3,13 @@ use wasmer_runtime::{func, imports, Func};
 
 use svm_app::types::HostCtx;
 use svm_common::{Address, State};
+use svm_layout::DataLayout;
 use svm_runtime::{
     gas::MaybeGas,
     helpers::DataWrapper,
     testing::{self, instance_storage2},
     vmcalls,
 };
-use svm_storage2::layout::DataLayout;
 
 macro_rules! assert_vars {
     ($instance:expr, $( $var_id:expr => $expected:expr), *) => {{
@@ -21,7 +21,7 @@ macro_rules! assert_vars {
 
 macro_rules! assert_storage {
     ($instance:expr, $($var_id:expr => $expected:expr), *) => {{
-        use svm_storage2::layout::VarId;
+        use svm_layout::VarId;
 
         let storage = instance_storage2(&$instance);
 

--- a/crates/svm-storage2/src/app/mod.rs
+++ b/crates/svm-storage2/src/app/mod.rs
@@ -6,7 +6,7 @@ use raw::{RawChange, RawStorage};
 mod kv;
 pub use kv::AppKVStore;
 
-use crate::layout::{DataLayout, VarId};
+use svm_layout::{DataLayout, VarId};
 
 ///
 /// The `AppStorage` manages a running app's storage.

--- a/crates/svm-storage2/src/layout/mod.rs
+++ b/crates/svm-storage2/src/layout/mod.rs
@@ -1,5 +1,0 @@
-mod builder;
-mod layout;
-
-pub use builder::DataLayoutBuilder;
-pub use layout::{DataLayout, VarId};

--- a/crates/svm-storage2/src/lib.rs
+++ b/crates/svm-storage2/src/lib.rs
@@ -13,6 +13,3 @@ pub mod app;
 
 /// Key-value abstraction
 pub mod kv;
-
-/// App's data-layout
-pub mod layout;


### PR DESCRIPTION
# Motivation

When building a [`template` transaction][build] using `svm_encode_app_template` the `DataLayout` is should be given `svm_byte_array`.

We need to parse it into `DataLayout`


[build]: https://github.com/spacemeshos/svm/blob/1424617fde68a27effbf4c41bc407b219174b9ce/crates/svm-runtime-c-api/src/api.rs#L1261