### PR TITLE
Making `AppStorage` `State`-aware 

### DIFF
--- a/crates/svm-storage2/src/app/kv.rs
+++ b/crates/svm-storage2/src/app/kv.rs
@@ -6,6 +6,10 @@ use crate::kv::StatefulKVStore;
 use svm_common::{Address, DefaultKeyHasher, KeyHasher, State};
 use svm_kv::traits::KVStore;
 
+/// An application-aware (and `State`-aware) key-value store interface responsible of
+/// mapping `u32` input keys (given as a 4 byte-length slice) to global keys under a raw key-value store.
+///
+/// The mapping is dependant on the contextual app's `Address` (see the `new` method).
 pub struct AppKVStore {
     pub(crate) app_addr: Address,
 
@@ -73,5 +77,14 @@ impl AppKVStore {
     #[inline]
     fn hash(&self, bytes: &[u8]) -> Vec<u8> {
         DefaultKeyHasher::hash(bytes).to_vec()
+    }
+}
+
+impl Clone for AppKVStore {
+    fn clone(&self) -> Self {
+        Self {
+            app_addr: self.app_addr.clone(),
+            raw_kv: Rc::clone(&self.raw_kv),
+        }
     }
 }

--- a/crates/svm-storage2/src/app/raw.rs
+++ b/crates/svm-storage2/src/app/raw.rs
@@ -1,8 +1,11 @@
 use std::collections::HashMap;
 
+use svm_common::State;
 use svm_kv::traits::KVStore;
 
 use super::AppKVStore;
+
+use crate::kv::StatefulKVStore;
 
 /// Interface against the key-value store.
 /// Data is manipulated using `offset` and `length`.
@@ -36,6 +39,16 @@ impl RawStorage {
             app_kv,
             kv_value_size,
         }
+    }
+
+    #[inline]
+    pub fn rewind(&mut self, state: &State) {
+        self.app_kv.rewind(state)
+    }
+
+    #[inline]
+    pub fn head(&self) -> State {
+        self.app_kv.head()
     }
 
     /// Reads the raw data under `offset, offset + 1, ..., offset + length - 1`
@@ -151,11 +164,9 @@ mod tests {
             use std::{cell::RefCell, rc::Rc};
 
             use crate::app::AppKVStore;
-            use crate::kv::FakeKV;
+            use crate::kv::{FakeKV, StatefulKVStore};
 
-            use svm_kv::traits::KVStore;
-
-            let raw_kv: Rc<RefCell<dyn KVStore>> = Rc::new(RefCell::new(FakeKV::new()));
+            let raw_kv: Rc<RefCell<dyn StatefulKVStore>> = Rc::new(RefCell::new(FakeKV::new()));
             AppKVStore::new($app_addr, &raw_kv)
         }};
     }

--- a/crates/svm-storage2/src/lib.rs
+++ b/crates/svm-storage2/src/lib.rs
@@ -1,7 +1,7 @@
-#![allow(missing_docs)]
-#![allow(unused)]
-#![allow(dead_code)]
-#![allow(unreachable_code)]
+#![deny(missing_docs)]
+#![deny(unused)]
+#![deny(dead_code)]
+#![deny(unreachable_code)]
 
 //! This crate is responsible on managing the App's storage.
 //!
@@ -13,3 +13,6 @@ pub mod app;
 
 /// Key-value abstraction
 pub mod kv;
+
+/// Tests helpers
+pub mod testing;

--- a/crates/svm-storage2/src/lib.rs
+++ b/crates/svm-storage2/src/lib.rs
@@ -1,7 +1,7 @@
-#![deny(missing_docs)]
-#![deny(unused)]
-#![deny(dead_code)]
-#![deny(unreachable_code)]
+#![allow(missing_docs)]
+#![allow(unused)]
+#![allow(dead_code)]
+#![allow(unreachable_code)]
 
 //! This crate is responsible on managing the App's storage.
 //!

--- a/crates/svm-storage2/src/testing.rs
+++ b/crates/svm-storage2/src/testing.rs
@@ -1,0 +1,21 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use svm_common::Address;
+
+use crate::app::AppKVStore;
+use crate::kv::{FakeKV, StatefulKVStore};
+
+/// Creates an in-memory stateful key-value store and returns it wrapped within `Rc<RefCell<..>>`
+pub fn create_raw_kv() -> Rc<RefCell<dyn StatefulKVStore>> {
+    Rc::new(RefCell::new(FakeKV::new()))
+}
+
+/// Creates an `AppKVStore` for app having `Address = app_addr`.
+///
+/// The underlying raw key-value store is in-memory (see `create_raw_kv`).
+pub fn create_app_kv(app_addr: Address) -> AppKVStore {
+    let raw_kv = create_raw_kv();
+
+    AppKVStore::new(app_addr, &raw_kv)
+}

--- a/crates/svm-storage2/tests/app_storage_tests.rs
+++ b/crates/svm-storage2/tests/app_storage_tests.rs
@@ -1,0 +1,70 @@
+use svm_layout::{DataLayout, VarId};
+use svm_storage2::{app::AppStorage, testing};
+
+use svm_common::Address;
+
+macro_rules! assert_vars {
+        ($app:expr, $($var_id:expr => $expected:expr), *) => {{
+            $(
+                let actual = $app.read_var(VarId($var_id));
+                assert_eq!(actual, $expected);
+             )*
+        }};
+    }
+
+macro_rules! write_vars {
+        ($app:expr, $($var_id:expr => $value:expr), *) => {{
+            $(
+                $app.write_var(VarId($var_id), $value.to_vec());
+             )*
+        }};
+    }
+
+#[test]
+fn app_storage_vars_are_persisted_only_on_commit() {
+    // `var #0` consumes 4 bytes (offsets: `[0..4)`)
+    // `var #1` consumes 2 bytes (offsets: `[4, 6)`)
+    let layout = DataLayout::from(vec![4, 2].as_slice());
+
+    let addr = Address::of("my-app");
+    let kv = testing::create_app_kv(addr);
+
+    let mut app = AppStorage::new(layout.clone(), kv.clone());
+
+    // vars are initialized with zeros
+    assert_vars!(app, 0 => [0, 0, 0, 0], 1 => [0, 0]);
+    write_vars!(app, 0 => [10, 20, 30, 40], 1 => [50, 60]);
+
+    // vars latest version are in memory (uncommitted yet)
+    assert_vars!(app, 0 => [10, 20, 30, 40], 1 => [50, 60]);
+
+    // spin a new app with no in-memory dirty data
+    let app2 = AppStorage::new(layout.clone(), kv.clone());
+
+    // `app`'s' uncomitted changes are not reflected yet
+    assert_vars!(app2, 0 => [0, 0, 0, 0], 1 => [0, 0]);
+
+    // now, we'll commit the dirty changes
+    let _state = app.commit();
+
+    // we'll spin a new app with no caching
+    let app3 = AppStorage::new(layout.clone(), kv.clone());
+
+    // asserting that `commit` persisted the data
+    assert_vars!(app3, 0 => [10, 20, 30, 40], 1 => [50, 60]);
+}
+
+#[test]
+#[cfg(debug_assertions)]
+#[should_panic]
+fn app_storage_write_var_value_should_match_layout_length() {
+    // `var #0` consumes 4 bytes (i.e `length = 4`)
+    let layout: DataLayout = vec![4].into();
+    let addr = Address::of("my-app");
+    let kv = testing::create_app_kv(addr);
+
+    let mut app = AppStorage::new(layout, kv);
+
+    // calling `write_var` with 2-byte value (expected variable's to value to be 4 bytes)
+    app.write_var(VarId(0), vec![0, 0]);
+}


### PR DESCRIPTION
# Motivation

After calling `commit` on an `AppStorage` instance, the executed application's `State` is being changed. We need to be able to propagate the new `State` back to the `AppStorage`.

This is required so that an executing `Runtime` can return in the `Receipt`(s) the new `State` of the application. 