### PR TITLE
`getXXX/setXXX` store each int in Little-Endian format

### DIFF
--- a/crates/svm-runtime/src/vmcalls/storage.rs
+++ b/crates/svm-runtime/src/vmcalls/storage.rs
@@ -1,6 +1,6 @@
 use crate::{helpers, use_gas};
 
-use byteorder::{BigEndian, ByteOrder};
+use byteorder::{ByteOrder, LittleEndian};
 use wasmer_runtime::Ctx as WasmerCtx;
 
 use svm_layout::VarId;
@@ -20,14 +20,14 @@ pub fn get32(ctx: &mut WasmerCtx, var_id: u32) -> u32 {
 
     assert!(nbytes <= 4);
 
-    let num = BigEndian::read_uint(&bytes, nbytes);
+    let num = LittleEndian::read_uint(&bytes, nbytes);
 
     debug_assert!(num <= std::u32::MAX as u64);
 
     num as u32
 }
 
-/// Sets the data of variable `var_id` to Big-Endian representation of `value`.
+/// Sets the data of variable `var_id` to Little-Endian representation of `value`.
 ///
 /// # Panics
 ///
@@ -42,7 +42,7 @@ pub fn set32(ctx: &mut WasmerCtx, var_id: u32, value: u32) {
     assert!(nbytes <= 4);
 
     let mut buf = vec![0; nbytes as usize];
-    BigEndian::write_uint(&mut buf, value as u64, nbytes as usize);
+    LittleEndian::write_uint(&mut buf, value as u64, nbytes as usize);
 
     storage.write_var(VarId(var_id), buf);
 }
@@ -62,10 +62,10 @@ pub fn get64(ctx: &mut WasmerCtx, var_id: u32) -> u64 {
 
     assert!(nbytes <= 8);
 
-    BigEndian::read_uint(&bytes, nbytes)
+    LittleEndian::read_uint(&bytes, nbytes)
 }
 
-/// Sets the data of variable `var_id` to Big-Endian representation of `value`.
+/// Sets the data of variable `var_id` to Little-Endian representation of `value`.
 ///
 /// # Panics
 ///
@@ -80,7 +80,7 @@ pub fn set64(ctx: &mut WasmerCtx, var_id: u32, value: u64) {
     assert!(nbytes <= 8);
 
     let mut buf = vec![0; nbytes as usize];
-    BigEndian::write_uint(&mut buf, value, nbytes as usize);
+    LittleEndian::write_uint(&mut buf, value, nbytes as usize);
 
     storage.write_var(VarId(var_id), buf);
 }
@@ -101,14 +101,14 @@ pub fn get160(ctx: &mut WasmerCtx, var_id: u32) -> (u64, u64, u32) {
 
     assert_eq!(nbytes, 20);
 
-    let a = BigEndian::read_u64(&bytes[0..8]);
-    let b = BigEndian::read_u64(&bytes[8..16]);
-    let c = BigEndian::read_u32(&bytes[16..20]);
+    let a = LittleEndian::read_u64(&bytes[0..8]);
+    let b = LittleEndian::read_u64(&bytes[8..16]);
+    let c = LittleEndian::read_u32(&bytes[16..20]);
 
     (a, b, c)
 }
 
-/// Sets the data of variable `var_id` to Big-Endian representation of 20-bytes held together by `a`, `b` and `c`.
+/// Sets the data of variable `var_id` to Little-Endian representation of 20-bytes held together by `a`, `b` and `c`.
 /// Parameter `a` hold the most-significant 8-bytes, 'c' the least significant 8-bytes and `b` the remaining middle 4-byte.  
 ///
 /// In total `len(a) + len(b) + len(c) = 20` bytes.
@@ -126,9 +126,9 @@ pub fn set160(ctx: &mut WasmerCtx, var_id: u32, a: u64, b: u64, c: u32) {
 
     let mut buf = vec![0; 20];
 
-    BigEndian::write_u64(&mut buf[0..8], a);
-    BigEndian::write_u64(&mut buf[8..16], b);
-    BigEndian::write_u32(&mut buf[16..20], c);
+    LittleEndian::write_u64(&mut buf[0..8], a);
+    LittleEndian::write_u64(&mut buf[8..16], b);
+    LittleEndian::write_u32(&mut buf[16..20], c);
 
     storage.write_var(VarId(var_id), buf);
 }
@@ -149,15 +149,15 @@ pub fn get256(ctx: &mut WasmerCtx, var_id: u32) -> (u64, u64, u64, u64) {
 
     assert_eq!(nbytes, 32);
 
-    let a = BigEndian::read_u64(&bytes[0..8]);
-    let b = BigEndian::read_u64(&bytes[8..16]);
-    let c = BigEndian::read_u64(&bytes[16..24]);
-    let d = BigEndian::read_u64(&bytes[24..32]);
+    let a = LittleEndian::read_u64(&bytes[0..8]);
+    let b = LittleEndian::read_u64(&bytes[8..16]);
+    let c = LittleEndian::read_u64(&bytes[16..24]);
+    let d = LittleEndian::read_u64(&bytes[24..32]);
 
     (a, b, c, d)
 }
 
-/// Sets the data of variable `var_id` to Big-Endian representation of 32-bytes held together by `a`, `b`, `c` and `d`.
+/// Sets the data of variable `var_id` to Little-Endian representation of 32-bytes held together by `a`, `b`, `c` and `d`.
 ///
 /// In total `len(a) + len(b) + len(c) + len(d) = 32` bytes.
 ///
@@ -174,10 +174,10 @@ pub fn set256(ctx: &mut WasmerCtx, var_id: u32, a: u64, b: u64, c: u64, d: u64) 
 
     let mut buf = vec![0; 32];
 
-    BigEndian::write_u64(&mut buf[0..8], a);
-    BigEndian::write_u64(&mut buf[8..16], b);
-    BigEndian::write_u64(&mut buf[16..24], c);
-    BigEndian::write_u64(&mut buf[24..32], d);
+    LittleEndian::write_u64(&mut buf[0..8], a);
+    LittleEndian::write_u64(&mut buf[8..16], b);
+    LittleEndian::write_u64(&mut buf[16..24], c);
+    LittleEndian::write_u64(&mut buf[24..32], d);
 
     storage.write_var(VarId(var_id), buf);
 }

--- a/crates/svm-runtime/tests/runtime_tests.rs
+++ b/crates/svm-runtime/tests/runtime_tests.rs
@@ -169,7 +169,7 @@ fn default_runtime_spawn_app_with_ctor_reaches_oog() {
 }
 
 #[test]
-fn runtime_spawn_app_with_ctor_with_enough_gas() {
+fn default_runtime_spawn_app_with_ctor_with_enough_gas() {
     let mut runtime = default_runtime!();
 
     // 1) deploying the template
@@ -218,7 +218,7 @@ fn runtime_spawn_app_with_ctor_with_enough_gas() {
     let storage = runtime.open_app_storage(&addr, &state, &layout);
 
     let var = storage.read_var(VarId(0));
-    assert_eq!(var, 10_20_30_40_50_60_70_80u64.to_be_bytes());
+    assert_eq!(var, 10_20_30_40_50_60_70_80u64.to_le_bytes());
 }
 
 #[test]
@@ -274,7 +274,7 @@ fn default_runtime_exec_app() {
     let storage = runtime.open_app_storage(&app_addr, &state, &layout);
 
     let var = storage.read_var(VarId(0));
-    assert_eq!(var, 10u32.to_be_bytes());
+    assert_eq!(var, 10u32.to_le_bytes());
 }
 
 #[test]
@@ -382,5 +382,5 @@ fn default_runtime_func_buf() {
     let storage = runtime.open_app_storage(&app_addr, &state, &layout);
 
     let var = storage.read_var(VarId(0));
-    assert_eq!(var, 0x80_70_60_50_40_30_20_10u64.to_be_bytes());
+    assert_eq!(var, 0x80_70_60_50_40_30_20_10u64.to_le_bytes());
 }

--- a/crates/svm-runtime/tests/vmcalls_tests.rs
+++ b/crates/svm-runtime/tests/vmcalls_tests.rs
@@ -124,7 +124,7 @@ fn vmcalls_get32_set32() {
     var_add32!(instance, 1, 10); // adding 10 to var #1
 
     assert_vars32!(instance, 0 => 5, 1 => 10);
-    assert_storage!(instance, 0 => [0, 0, 0, 5], 1 => [0, 10]);
+    assert_storage!(instance, 0 => [5, 0, 0, 0], 1 => [10, 0]);
 }
 
 #[test]
@@ -157,7 +157,7 @@ fn vmcalls_get64_set64() {
     var_add64!(instance, 1, 10); // adding 10 to var #1
 
     assert_vars64!(instance, 0 => 5, 1 => 10);
-    assert_storage!(instance, 0 => [0, 0, 0, 5], 1 => [0, 10]);
+    assert_storage!(instance, 0 => [5, 0, 0, 0], 1 => [10, 0]);
 }
 
 #[test]

--- a/crates/svm-storage/src/app/mod.rs
+++ b/crates/svm-storage/src/app/mod.rs
@@ -79,7 +79,7 @@ impl AppStorage {
     pub fn write_var(&mut self, var_id: VarId, value: Vec<u8>) {
         let (_off, len) = self.var_layout(var_id);
 
-        debug_assert_eq!(value.len(), len as usize);
+        assert_eq!(value.len(), len as usize);
 
         self.uncommitted.insert(var_id, value);
     }


### PR DESCRIPTION
# Motivation

Since WASM's Memory is laying out integers in Little-Endian order we need to adapt the storage vmcalls `getXXX/setXXX` to be Little-Endian too.

Currently, these vmcalls are storing integers in Big-Endian order and that could cause issues when using the `get160/set160` and `get256/set256` vmcalls.

After moving to use wasmer with the `cranelift` compiler (which support wasm muti-return values) we could make the `get160/set160` and `get256/set256` functional.

Then we could add tests the simulate sending `Address` and `PubKey` via the `function buffer`.