### PR TITLE
Temporarily substituting wasmer's `singlepass compiler` for `cranelift`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,9 +59,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.53.2"
+version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bb26d6a69a335b8cb0e7c7e9775cd5666611dc50a37177c3f2cedcfc040e8c8"
+checksum = "c72a978d268b1d70b0e963217e60fdabd9523a941457a6c42a7315d15c7e89e5"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -95,9 +95,9 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "blake3"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68df31bdf2bbb567e5adf8f21ac125dc0e897b1381e7b841f181521f06fc3134"
+checksum = "423897d97e11b810c9da22458400b28ec866991c711409073662eb34dc44bfff"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -133,9 +133,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.53"
+version = "1.0.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "404b1fe4f65288577753b17e3b36a04596ee784493ec249bf81c7f2d2acd751c"
+checksum = "7bbb73db36c1246e9034e307d0fba23f9a2e251faa47ade70c1bd252220c8311"
 dependencies = [
  "jobserver",
 ]
@@ -206,6 +206,113 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
+name = "cranelift-bforest"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45a9c21f8042b9857bda93f6c1910b9f9f24100187a3d3d52f214a34e3dc5818"
+dependencies = [
+ "cranelift-entity",
+]
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7853f77a6e4a33c67a69c40f5e1bb982bd2dc5c4a22e17e67b65bbccf9b33b2e"
+dependencies = [
+ "byteorder",
+ "cranelift-bforest",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-entity",
+ "gimli",
+ "log",
+ "smallvec",
+ "target-lexicon",
+ "thiserror",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "084cd6d5fb0d1da28acd72c199471bfb09acc703ec8f3bf07b1699584272a3b9"
+dependencies = [
+ "cranelift-codegen-shared",
+ "cranelift-entity",
+]
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "701b599783305a58c25027a4d73f2d6b599b2d8ef3f26677275f480b4d51e05d"
+
+[[package]]
+name = "cranelift-entity"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b88e792b28e1ebbc0187b72ba5ba880dad083abe9231a99d19604d10c9e73f38"
+
+[[package]]
+name = "cranelift-native"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32daf082da21c0c05d93394ff4842c2ab7c4991b1f3186a1d952f8ac660edd0b"
+dependencies = [
+ "cranelift-codegen",
+ "raw-cpuid",
+ "target-lexicon",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "maybe-uninit",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "lazy_static",
+ "maybe-uninit",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab6bffe714b6bb07e42f201352c34f51fefd355ace793f9e638ebd52d23f98d2"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "lazy_static",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -260,6 +367,12 @@ dependencies = [
  "byteorder",
  "memmap",
 ]
+
+[[package]]
+name = "either"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 
 [[package]]
 name = "env_logger"
@@ -319,6 +432,16 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "gimli"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81dd6190aad0f05ddbbf3245c54ed14ca4aa6dd32f22312b70d8f168c3e3e633"
+dependencies = [
+ "byteorder",
+ "indexmap",
 ]
 
 [[package]]
@@ -396,9 +519,9 @@ checksum = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 
 [[package]]
 name = "libc"
-version = "0.2.70"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3baa92041a6fec78c687fa0cc2b3fae8884f743d672cf551bed1d6dac6988d0f"
+checksum = "9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49"
 
 [[package]]
 name = "libloading"
@@ -447,6 +570,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
+name = "maybe-uninit"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
+
+[[package]]
 name = "memchr"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -460,6 +589,15 @@ checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4fc2c02a7e374099d4ee95a193111f72d2110197fe200272371758f6c3643d8"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -483,6 +621,16 @@ checksum = "0b471253da97532da4b61552249c521e01e736071f71c1a4f7ebbfbf0a06aad6"
 dependencies = [
  "memchr",
  "version_check",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -548,9 +696,9 @@ checksum = "237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.13"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53f5ffe53a6b28e37c9c1ce74893477864d64f74778a93a4beb43c8fa167f639"
+checksum = "beae6331a816b1f65d04c45b078fd8e6c93e8071771f41b8163255bbd8d7c8fa"
 dependencies = [
  "unicode-xid",
 ]
@@ -612,6 +760,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "raw-cpuid"
+version = "7.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a349ca83373cfa5d6dbb66fd76e58b2cca08da71a5f6400de0a0a6a9bceeaf"
+dependencies = [
+ "bitflags",
+ "cc",
+ "rustc_version",
+]
+
+[[package]]
+name = "rayon"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db6ce3297f9c85e16621bb8cca38a06779ffc31bb8184e1be4bed2be4678a098"
+dependencies = [
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08a89b46efaf957e52b18062fb2f4660f8b8a4dde1807ca002690868ef2c85a9"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-queue",
+ "crossbeam-utils",
+ "lazy_static",
+ "num_cpus",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -619,9 +802,9 @@ checksum = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 
 [[package]]
 name = "regex"
-version = "1.3.7"
+version = "1.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6020f034922e3194c711b82a627453881bc4682166cabb07134a10c26ba7692"
+checksum = "9c3780fcf44b193bc4d09f36d2a3c87b251da4a046c87795a0d35f4f927ad8e6"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -631,9 +814,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.17"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe5bd57d1d7414c6b5ed48563a2c855d995ff777729dcd91c369ec7fea395ae"
+checksum = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
 
 [[package]]
 name = "remove_dir_all"
@@ -671,9 +854,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3d612bc64430efeb3f7ee6ef26d590dce0c43249217bddc62112540c7941e1"
+checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "scopeguard"
@@ -698,9 +881,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.110"
+version = "1.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99e7b308464d16b56eba9964e4972a3eee817760ab60d88c3f86e1fecb08204c"
+checksum = "c9124df5b40cbd380080b2cc6ab894c040a3070d995f5c9dc77e18c34a8ae37d"
 dependencies = [
  "serde_derive",
 ]
@@ -726,9 +909,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.110"
+version = "1.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818fbf6bfa9a42d3bfcaca148547aa00c7b915bec71d1757aa2d44ca68771984"
+checksum = "3f2c3ac8e6ca1e9c80b8be1023940162bf81ae3cffbb1809474152f2ce1eb250"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -798,11 +981,9 @@ dependencies = [
  "svm-storage",
  "tiny-keccak",
  "wabt",
- "wasmer-middleware-common",
  "wasmer-runtime",
  "wasmer-runtime-c-api",
  "wasmer-runtime-core",
- "wasmer-singlepass-backend",
 ]
 
 [[package]]
@@ -855,10 +1036,9 @@ version = "0.0.0"
 dependencies = [
  "svm-common",
  "wabt",
- "wasmer-middleware-common",
+ "wasmer-clif-backend",
  "wasmer-runtime",
  "wasmer-runtime-core",
- "wasmer-singlepass-backend",
  "wasmparser 0.45.2",
 ]
 
@@ -904,7 +1084,6 @@ dependencies = [
  "svm-layout",
  "svm-storage",
  "wabt",
- "wasmer-middleware-common",
  "wasmer-runtime",
  "wasmer-runtime-core",
 ]
@@ -926,10 +1105,8 @@ dependencies = [
  "svm-runtime",
  "svm-storage",
  "wabt",
- "wasmer-runtime",
  "wasmer-runtime-c-api",
  "wasmer-runtime-core",
- "wasmer-singlepass-backend",
 ]
 
 [[package]]
@@ -943,9 +1120,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.22"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1425de3c33b0941002740a420b1a906a350b88d08b82b2c8a01035a3f9447bac"
+checksum = "93a56fabc59dce20fe48b6c832cc249c713e7ed88fa28b0ee0a3bfcaae5fe4e2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -988,6 +1165,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b13f926965ad00595dd129fa12823b04bbf866e9085ab0a5f2b05b850fbfc344"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "893582086c2f98cde18f906265a65b5030a074b1046c674ae898be6519a7f479"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1043,9 +1240,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
+checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 
 [[package]]
 name = "void"
@@ -1093,11 +1290,54 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmer-middleware-common"
+name = "wasmer-clif-backend"
 version = "0.17.0"
 source = "git+https://github.com/spacemeshos/wasmer?branch=develop#0575a7ed3f8742c3842afbc455072d957af7f6ce"
 dependencies = [
+ "byteorder",
+ "cranelift-codegen",
+ "cranelift-entity",
+ "cranelift-native",
+ "libc",
+ "nix",
+ "rayon",
+ "serde",
+ "serde-bench",
+ "serde_bytes",
+ "serde_derive",
+ "target-lexicon",
+ "wasmer-clif-fork-frontend",
+ "wasmer-clif-fork-wasm",
  "wasmer-runtime-core",
+ "wasmer-win-exception-handler",
+ "wasmparser 0.51.4",
+ "winapi",
+]
+
+[[package]]
+name = "wasmer-clif-fork-frontend"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c23f2824f354a00a77e4b040eef6e1d4c595a8a3e9013bad65199cc8dade9a5a"
+dependencies = [
+ "cranelift-codegen",
+ "log",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "wasmer-clif-fork-wasm"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a35e21d3aebc51cc6ebc0e830cf8458a9891c3482fb3c65ad18d408102929ae5"
+dependencies = [
+ "cranelift-codegen",
+ "cranelift-entity",
+ "log",
+ "thiserror",
+ "wasmer-clif-fork-frontend",
+ "wasmparser 0.51.4",
 ]
 
 [[package]]
@@ -1109,8 +1349,8 @@ dependencies = [
  "memmap",
  "serde",
  "serde_derive",
+ "wasmer-clif-backend",
  "wasmer-runtime-core",
- "wasmer-singlepass-backend",
 ]
 
 [[package]]
@@ -1168,6 +1408,17 @@ dependencies = [
  "serde_derive",
  "smallvec",
  "wasmer-runtime-core",
+]
+
+[[package]]
+name = "wasmer-win-exception-handler"
+version = "0.17.0"
+source = "git+https://github.com/spacemeshos/wasmer?branch=develop#0575a7ed3f8742c3842afbc455072d957af7f6ce"
+dependencies = [
+ "cc",
+ "libc",
+ "wasmer-runtime-core",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ features = ["lz4"]
 default-features = false
 git = "https://github.com/spacemeshos/wasmer"
 branch = "develop"
-features = ["singlepass"]
+features = ["default-backend-cranelift"]
 
 [dependencies.wasmer-runtime-core]
 default-features = false
@@ -40,16 +40,15 @@ branch = "develop"
 default-features = false
 git = "https://github.com/spacemeshos/wasmer"
 branch = "develop"
-features = ["singlepass-backend"]
 
-[dependencies.wasmer-singlepass-backend]
-git = "https://github.com/spacemeshos/wasmer"
-branch = "develop"
+# [dependencies.wasmer-singlepass-backend]
+# git = "https://github.com/spacemeshos/wasmer"
+# branch = "develop"
 
-[dependencies.wasmer-middleware-common]
-default-features = false
-git = "https://github.com/spacemeshos/wasmer"
-branch = "develop"
+# [dependencies.wasmer-middleware-common]
+# default-features = false
+# git = "https://github.com/spacemeshos/wasmer"
+# branch = "develop"
 
 [dependencies]
 libc = "0.2"

--- a/crates/svm-compiler/Cargo.toml
+++ b/crates/svm-compiler/Cargo.toml
@@ -18,28 +18,29 @@ version = "0.0.0"
 default-features = false
 git = "https://github.com/spacemeshos/wasmer"
 branch = "develop"
-features = ["default-backend-singlepass"]
+features = ["default-backend-cranelift"]
+# features = ["default-backend-singlepass"]
 
 [dependencies.wasmer-runtime-core]
 default-features = false
 git = "https://github.com/spacemeshos/wasmer"
 branch = "develop"
 
-[dependencies.wasmer-singlepass-backend]
+[dependencies.wasmer-clif-backend]
 git = "https://github.com/spacemeshos/wasmer"
 branch = "develop"
 
-[dependencies.wasmer-middleware-common]
-default-features = false
-git = "https://github.com/spacemeshos/wasmer"
-branch = "develop"
+# [dependencies.wasmer-singlepass-backend]
+# git = "https://github.com/spacemeshos/wasmer"
+# branch = "develop"
+
+# [dependencies.wasmer-middleware-common]
+# default-features = false
+# git = "https://github.com/spacemeshos/wasmer"
+# branch = "develop"
 
 [dependencies.wasmparser]
 version = "0.45.0"
 
 [dev-dependencies]
 wabt = "0.7.4"
-
-[features]
-default = ["wasm_1_0_0"]
-wasm_1_0_0 = []

--- a/crates/svm-compiler/src/compiler.rs
+++ b/crates/svm-compiler/src/compiler.rs
@@ -1,26 +1,37 @@
+use wasmer_clif_backend::CraneliftCompiler;
 use wasmer_runtime_core::{error::CompileResult, Module};
 
-use crate::middleware::ValidationMiddleware;
-use wasmer_middleware_common::metering::Metering;
-use wasmer_runtime_core::codegen::{MiddlewareChain, StreamingCompiler};
-use wasmer_singlepass_backend::ModuleCodeGenerator as SinglePassMCG;
+// use crate::middleware::ValidationMiddleware;
+
+// use wasmer_middleware_common::metering::Metering;
+// use wasmer_runtime_core::codegen::{MiddlewareChain, StreamingCompiler};
+// use wasmer_singlepass_backend::ModuleCodeGenerator as SinglePassMCG;
 
 /// This function is responsible on compiling a wasm program using the `wasmer singlepass` compiler along
 /// with the the middlewares required by `SVM`.
+// #[must_use]
+// pub fn compile_singlepass(
+//     wasm: &[u8],
+//     gas_limit: u64,
+//     gas_metering: bool,
+// ) -> CompileResult<Module> {
+//     let compiler: StreamingCompiler<SinglePassMCG, _, _, _, _> =
+//         StreamingCompiler::new(move || {
+//             let mut chain = MiddlewareChain::new();
+
+//             chain.push(ValidationMiddleware::new());
+
+//             if gas_metering {
+//                 chain.push(Metering::new(gas_limit))
+//             }
+
+//             chain
+//         });
+
+//     wasmer_runtime_core::compile_with(wasm, &compiler)
+// }
+
 #[must_use]
-pub fn compile_program(wasm: &[u8], gas_limit: u64, gas_metering: bool) -> CompileResult<Module> {
-    let compiler: StreamingCompiler<SinglePassMCG, _, _, _, _> =
-        StreamingCompiler::new(move || {
-            let mut chain = MiddlewareChain::new();
-
-            chain.push(ValidationMiddleware::new());
-
-            if gas_metering {
-                chain.push(Metering::new(gas_limit))
-            }
-
-            chain
-        });
-
-    wasmer_runtime_core::compile_with(wasm, &compiler)
+pub fn compile_program(wasm: &[u8], _gas_limit: u64, _gas_metering: bool) -> CompileResult<Module> {
+    wasmer_runtime_core::compile_with(wasm, &CraneliftCompiler::new())
 }

--- a/crates/svm-compiler/src/lib.rs
+++ b/crates/svm-compiler/src/lib.rs
@@ -7,6 +7,6 @@
 //! `wasmer` compiler milddlewares for `SVM` usage.
 
 mod compiler;
-mod middleware;
+// mod middleware;
 
 pub use compiler::compile_program;

--- a/crates/svm-runtime-c-api/Cargo.toml
+++ b/crates/svm-runtime-c-api/Cargo.toml
@@ -9,11 +9,12 @@ publish = false
 [lib]
 crate-type = ["cdylib", "staticlib", "rlib"]
 
-[dependencies.wasmer-runtime]
-default-features = false
-git = "https://github.com/spacemeshos/wasmer"
-branch = "develop"
-features = ["default-backend-singlepass"]
+# [dependencies.wasmer-runtime]
+# default-features = false
+# git = "https://github.com/spacemeshos/wasmer"
+# branch = "develop"
+# features = ["default-backend-cranelift"]
+# features = ["default-backend-singlepass"]
 
 [dependencies.wasmer-runtime-core]
 default-features = false
@@ -26,9 +27,9 @@ git = "https://github.com/spacemeshos/wasmer"
 branch = "develop"
 features = ["singlepass-backend"]
 
-[dependencies.wasmer-singlepass-backend]
-git = "https://github.com/spacemeshos/wasmer"
-branch = "develop"
+# [dependencies.wasmer-singlepass-backend]
+# git = "https://github.com/spacemeshos/wasmer"
+# branch = "develop"
 
 [dependencies.svm-runtime]
 default-features = false

--- a/crates/svm-runtime/Cargo.toml
+++ b/crates/svm-runtime/Cargo.toml
@@ -31,17 +31,18 @@ path = "../svm-gas"
 default-features = false
 git = "https://github.com/spacemeshos/wasmer"
 branch = "develop"
-features = ["default-backend-singlepass"]
+features = ["default-backend-cranelift"]
+# features = ["default-backend-singlepass"]
 
 [dependencies.wasmer-runtime-core]
 default-features = false
 git = "https://github.com/spacemeshos/wasmer"
 branch = "develop"
 
-[dependencies.wasmer-middleware-common]
-default-features = false
-git = "https://github.com/spacemeshos/wasmer"
-branch = "develop"
+# [dependencies.wasmer-middleware-common]
+# default-features = false
+# git = "https://github.com/spacemeshos/wasmer"
+# branch = "develop"
 
 [dependencies]
 log = "0.4"

--- a/crates/svm-runtime/src/helpers/gas.rs
+++ b/crates/svm-runtime/src/helpers/gas.rs
@@ -1,4 +1,4 @@
-use wasmer_middleware_common::metering::{get_points_used_ctx, set_points_used_ctx};
+// use wasmer_middleware_common::metering::{get_points_used_ctx, set_points_used_ctx};
 use wasmer_runtime::Ctx as WasmerCtx;
 use wasmer_runtime::Instance;
 
@@ -14,36 +14,38 @@ use crate::{
 /// Panics `Out of Gas` in case there is no sufficient gas left.
 #[inline]
 pub fn wasmer_use_gas(ctx: &mut WasmerCtx, gas: u64, gas_limit: u64) {
-    let used_gas = get_points_used_ctx(ctx);
-    let new_used_gas = used_gas + gas;
+    // let used_gas = get_points_used_ctx(ctx);
+    // let new_used_gas = used_gas + gas;
 
-    if new_used_gas <= gas_limit {
-        set_points_used_ctx(ctx, new_used_gas);
-    } else {
-        set_points_used_ctx(ctx, gas_limit);
+    // if new_used_gas <= gas_limit {
+    //     set_points_used_ctx(ctx, new_used_gas);
+    // } else {
+    //     set_points_used_ctx(ctx, gas_limit);
 
-        panic!("Out of Gas");
-    }
+    //     panic!("Out of Gas");
+    // }
 }
 
 /// On success returns the amount of gas used during App's execution.
 /// Of failure returs `OOGError` (Out-of-Gas).
 pub fn wasmer_gas_used(instance: &Instance) -> Result<MaybeGas, OOGError> {
-    let wasmer_ctx = instance.context();
+    Ok(MaybeGas::new())
 
-    let svm_ctx: &mut SvmCtx = unsafe { svm_common::from_raw_mut::<SvmCtx>(wasmer_ctx.data) };
+    // let wasmer_ctx = instance.context();
 
-    if svm_ctx.gas_metering {
-        let gas_used = get_points_used_ctx(&wasmer_ctx);
+    // let svm_ctx: &mut SvmCtx = unsafe { svm_common::from_raw_mut::<SvmCtx>(wasmer_ctx.data) };
 
-        if gas_used <= svm_ctx.gas_limit {
-            let gas_used = MaybeGas::with(gas_used);
+    // if svm_ctx.gas_metering {
+    //     let gas_used = get_points_used_ctx(&wasmer_ctx);
 
-            Ok(gas_used)
-        } else {
-            Err(OOGError {})
-        }
-    } else {
-        Ok(MaybeGas::new())
-    }
+    //     if gas_used <= svm_ctx.gas_limit {
+    //         let gas_used = MaybeGas::with(gas_used);
+
+    //         Ok(gas_used)
+    //     } else {
+    //         Err(OOGError {})
+    //     }
+    // } else {
+    //     Ok(MaybeGas::new())
+    // }
 }

--- a/crates/svm-runtime/tests/runtime_tests.rs
+++ b/crates/svm-runtime/tests/runtime_tests.rs
@@ -169,6 +169,7 @@ fn default_runtime_spawn_app_with_ctor_reaches_oog() {
 }
 
 #[test]
+#[ignore = "temporarily skipping this test until wasmer cranelift will support middlewares"]
 fn default_runtime_spawn_app_with_ctor_with_enough_gas() {
     let mut runtime = default_runtime!();
 
@@ -278,6 +279,7 @@ fn default_runtime_exec_app() {
 }
 
 #[test]
+#[ignore = "temporarily skipping this test until wasmer cranelift will support middlewares"]
 fn default_runtime_exec_app_reaches_oog() {
     let mut runtime = default_runtime!();
 


### PR DESCRIPTION
# Motivation

This PR substitutes the used wasmer compiler to `cranelift`. (it has Windows support).
It means that the gas-metering functionality won't work for now. 
Fortunately, this should be supported in wasmer soon.
