### PR TITLE
macOS: brew install automake

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,6 +18,9 @@ jobs:
         node: ['12']
         release: ["--release"]
     steps:
+    - name: Automake (macOS)
+      if:  matrix.os == 'macos-latest'
+      run: brew install automake
     - name: LLVM (Windows)
       if:  matrix.os == 'windows-latest'
       run: choco install llvm -y


### PR DESCRIPTION
# Motivation

The new wasmer requires `automake` which seems to be missing from the default macOS image of GitHub Actions.