### PR TITLE
add `capacity` to `svm_byte_array`

### DIFF
--- a/crates/svm-codec/src/app/mod.rs
+++ b/crates/svm-codec/src/app/mod.rs
@@ -1,4 +1,4 @@
-//!                   `Spawn-App` Raw Format
+//! `Spawn-App` Raw Format
 //!  ----------------------------------------------------------
 //!  |               |                                        |
 //!  |    `version`  |        `AppTemplate` (`Address`)       |

--- a/crates/svm-codec/src/receipt/deploy_template.rs
+++ b/crates/svm-codec/src/receipt/deploy_template.rs
@@ -1,4 +1,4 @@
-//!     `Deploy Template` Receipt Raw Format Version 0
+//! `Deploy Template` Receipt Raw Format Version 0
 //!
 //!  On success (`is_success = 1`)
 //!

--- a/crates/svm-codec/src/receipt/exec_app.rs
+++ b/crates/svm-codec/src/receipt/exec_app.rs
@@ -1,4 +1,4 @@
-//!         `Exec App` Receipt Raw Format Version 0
+//! `Exec App` Receipt Raw Format Version 0
 //!
 //!  On success (`is_success = 1`)
 //!  +---------------------------------------------------+

--- a/crates/svm-codec/src/receipt/spawn_app.rs
+++ b/crates/svm-codec/src/receipt/spawn_app.rs
@@ -1,4 +1,4 @@
-//!           `Spawn App` Receipt Raw Format Version 0
+//! `Spawn App` Receipt Raw Format Version 0
 //!
 //!  On success (`is_success = 1`)
 //!  +-----------------------------------------------------+

--- a/crates/svm-codec/src/template/mod.rs
+++ b/crates/svm-codec/src/template/mod.rs
@@ -1,4 +1,4 @@
-//!                  `AppTemplate` Raw Format
+//! `AppTemplate` Raw Format
 //!  +-----------------------------------------------------+
 //!  |            |                |                       |
 //!  |  version   |  name length   |         name          |

--- a/crates/svm-codec/src/transaction/mod.rs
+++ b/crates/svm-codec/src/transaction/mod.rs
@@ -1,4 +1,4 @@
-//!     Execute `AppTransaction` Raw Format Version 0.0
+//! Execute `AppTransaction` Raw Format Version 0.0
 //!  +-----------------------------------------------------+
 //!  |   proto     |                                       |
 //!  |  version    |            `AppAddress`               |

--- a/crates/svm-runtime-c-api/src/api.rs
+++ b/crates/svm-runtime-c-api/src/api.rs
@@ -873,8 +873,9 @@ pub unsafe extern "C" fn svm_imports_destroy(imports: *const c_void) {
 pub unsafe extern "C" fn svm_byte_array_destroy(bytes: svm_byte_array) {
     let ptr = bytes.bytes as *mut u8;
     let length = bytes.length as usize;
+    let capacity = bytes.capacity as usize;
 
-    let _ = Vec::from_raw_parts(ptr, length, length);
+    let _ = Vec::from_raw_parts(ptr, length, capacity);
 }
 
 /// Given a raw `deploy-template` transaction (the `bytes` parameter),

--- a/crates/svm-runtime-c-api/src/api.rs
+++ b/crates/svm-runtime-c-api/src/api.rs
@@ -289,7 +289,7 @@ pub unsafe extern "C" fn svm_imports_alloc(imports: *mut *mut c_void, count: u32
 /// // allocate one imports
 /// let mut imports = testing::imports_alloc(1);
 ///
-/// let import_name = "foo".into();
+/// let import_name = String::from("foo").into();
 /// let params = Vec::<WasmType>::new();
 /// let returns = Vec::<WasmType>::new();
 /// let func_ptr = foo as *const std::ffi::c_void;
@@ -514,7 +514,7 @@ pub unsafe extern "C" fn svm_memory_runtime_create(
 /// use svm_runtime_c_api::*;
 ///
 /// let mut runtime = std::ptr::null_mut();
-/// let path = "path goes here".into();
+/// let path = String::from("path goes here").into();
 /// let host = std::ptr::null_mut();
 /// let mut imports = testing::imports_alloc(0);
 /// let mut error = svm_byte_array::default();

--- a/crates/svm-runtime-c-api/src/byte_array.rs
+++ b/crates/svm-runtime-c-api/src/byte_array.rs
@@ -16,7 +16,7 @@ use std::{convert::TryFrom, string::FromUtf8Error};
 /// ```
 ///
 #[allow(non_camel_case_types)]
-#[derive(Copy, Clone)]
+#[derive(Clone)]
 #[repr(C)]
 pub struct svm_byte_array {
     /// Raw pointer to the beginning of array.
@@ -139,7 +139,7 @@ mod tests {
         assert_eq!(s1_len, bytes.length);
         assert_eq!(s1_capacity, bytes.capacity);
 
-        let s2 = String::try_from(bytes).unwrap();
+        let s2 = String::try_from(bytes.clone()).unwrap();
         assert_eq!(s2, "Hello World!".to_string());
         assert_ne!(s2.as_ptr(), bytes.bytes); // `s2` is a clone.
         assert_eq!(s2.len() as u32, bytes.length);

--- a/crates/svm-runtime-c-api/src/macros.rs
+++ b/crates/svm-runtime-c-api/src/macros.rs
@@ -72,6 +72,7 @@ macro_rules! impl_into_svm_byte_array {
                 $crate::svm_byte_array {
                     bytes: bytes.as_ptr(),
                     length,
+                    capacity: length,
                 }
             }
         }

--- a/crates/svm-runtime-c-api/src/types.rs
+++ b/crates/svm-runtime-c-api/src/types.rs
@@ -116,6 +116,7 @@ mod tests {
         let bytes = svm_byte_array {
             bytes: std::ptr::null(),
             length: 0,
+            capacity: 0,
         };
 
         let res: Result<Vec<WasmType>, io::Error> = Vec::try_from(bytes);

--- a/crates/svm-runtime-c-api/src/value.rs
+++ b/crates/svm-runtime-c-api/src/value.rs
@@ -158,7 +158,7 @@ mod tests {
         let bytes = svm_byte_array {
             bytes: raw.as_ptr(),
             length: raw.len() as u32,
-            capacity: raw.len() as u32,
+            capacity: raw.capacity() as u32,
         };
 
         let res: Result<Vec<WasmValue>, io::Error> = Vec::try_from(bytes);
@@ -172,7 +172,7 @@ mod tests {
         let bytes = svm_byte_array {
             bytes: raw.as_ptr(),
             length: raw.len() as u32,
-            capacity: raw.len() as u32,
+            capacity: raw.capacity() as u32,
         };
 
         let res: Result<Vec<WasmValue>, io::Error> = Vec::try_from(bytes);

--- a/crates/svm-runtime-c-api/src/value.rs
+++ b/crates/svm-runtime-c-api/src/value.rs
@@ -143,6 +143,7 @@ mod tests {
         let bytes = svm_byte_array {
             bytes: std::ptr::null(),
             length: 0,
+            capacity: 0,
         };
 
         let res: Result<Vec<WasmValue>, io::Error> = Vec::try_from(bytes);
@@ -157,6 +158,7 @@ mod tests {
         let bytes = svm_byte_array {
             bytes: raw.as_ptr(),
             length: raw.len() as u32,
+            capacity: raw.len() as u32,
         };
 
         let res: Result<Vec<WasmValue>, io::Error> = Vec::try_from(bytes);
@@ -170,6 +172,7 @@ mod tests {
         let bytes = svm_byte_array {
             bytes: raw.as_ptr(),
             length: raw.len() as u32,
+            capacity: raw.len() as u32,
         };
 
         let res: Result<Vec<WasmValue>, io::Error> = Vec::try_from(bytes);
@@ -183,6 +186,7 @@ mod tests {
         let bytes = svm_byte_array {
             bytes: raw.as_ptr(),
             length: raw.len() as u32,
+            capacity: raw.capacity() as u32,
         };
 
         let res: Result<Vec<WasmValue>, io::Error> = Vec::try_from(bytes);

--- a/crates/svm-runtime-c-api/tests/api_tests.rs
+++ b/crates/svm-runtime-c-api/tests/api_tests.rs
@@ -95,7 +95,7 @@ unsafe fn test_svm_runtime() {
     assert!(res.is_ok());
 
     // extract the `template-address` out of theh receipt
-    let receipt = raw::decode_receipt(template_receipt.into()).into_deploy_template();
+    let receipt = raw::decode_receipt(template_receipt.clone().into()).into_deploy_template();
     let template_addr: &Address = receipt.get_template_addr().inner();
     let template_addr: svm_byte_array = template_addr.into();
 
@@ -126,7 +126,7 @@ unsafe fn test_svm_runtime() {
     assert!(res.is_ok());
 
     // extracts the spawned-app `Address` and initial `State`.
-    let receipt = raw::decode_receipt(spawn_receipt.into()).into_spawn_app();
+    let receipt = raw::decode_receipt(spawn_receipt.clone().into()).into_spawn_app();
     let app_addr: &Address = receipt.get_app_addr().inner();
     let app_addr: svm_byte_array = app_addr.into();
 
@@ -145,7 +145,7 @@ unsafe fn test_svm_runtime() {
 
     // 4.1) validates tx and extracts its `App`'s `Address`
     let mut app_addr = svm_byte_array::default();
-    let res = api::svm_validate_tx(&mut app_addr, runtime, tx_bytes, &mut error);
+    let res = api::svm_validate_tx(&mut app_addr, runtime, tx_bytes.clone(), &mut error);
     assert!(res.is_ok());
 
     // 4.2) execute the app-transaction
@@ -155,14 +155,14 @@ unsafe fn test_svm_runtime() {
         &mut exec_receipt,
         runtime,
         tx_bytes,
-        init_state,
+        init_state.clone(),
         gas_metering,
         gas_limit,
         &mut error,
     );
     assert!(res.is_ok());
 
-    let _receipt = raw::decode_receipt(exec_receipt.into()).into_exec_app();
+    let _receipt = raw::decode_receipt(exec_receipt.clone().into()).into_exec_app();
 
     let _ = api::svm_byte_array_destroy(template_addr);
     let _ = api::svm_byte_array_destroy(app_addr);


### PR DESCRIPTION
Added `capacity` to `svm_byte_array` (the total number of allocated bytes).
It may be unequal and bigger than `length` if the `svm_byte_array` instance is an alias to an instance of a data structure such as `Vec` (which in order to properly get deallocated needs first to be re-constructed using the proper allocated capacity).

[Vec#leak](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.leak) wasn't used because in order to remove the surplus capacity it clones the data, while `svm_byte_array` is intended to be an alias. 

Closing https://github.com/spacemeshos/svm/issues/129.