### PR TITLE
Remove `host` raw pointer from the runtime context

### DIFF
--- a/crates/svm-runtime-c-api/src/api.rs
+++ b/crates/svm-runtime-c-api/src/api.rs
@@ -96,8 +96,6 @@ macro_rules! to_svm_byte_array {
 /// use svm_runtime_c_api::*;
 /// use svm_types::Address;
 ///
-/// let mut host = std::ptr::null_mut();
-///
 /// // allocate imports
 /// let mut imports = testing::imports_alloc(0);
 ///
@@ -110,7 +108,7 @@ macro_rules! to_svm_byte_array {
 /// let mut runtime = std::ptr::null_mut();
 /// let mut error = svm_byte_array::default();
 ///
-/// let res = unsafe { svm_memory_runtime_create(&mut runtime, kv, host, imports, &mut error) };
+/// let res = unsafe { svm_memory_runtime_create(&mut runtime, kv, imports, &mut error) };
 /// assert!(res.is_ok());
 ///
 /// let bytes = svm_byte_array::default();
@@ -148,13 +146,10 @@ pub unsafe extern "C" fn svm_validate_template(
 /// use svm_runtime_c_api::*;
 /// use svm_types::Address;
 ///
-/// let mut host = std::ptr::null_mut();
-///
 /// // allocate imports
 /// let mut imports = testing::imports_alloc(0);
 ///
 /// // create runtime
-///
 /// let mut kv = std::ptr::null_mut();
 /// let res = unsafe { svm_memory_state_kv_create(&mut kv) };
 /// assert!(res.is_ok());
@@ -162,7 +157,7 @@ pub unsafe extern "C" fn svm_validate_template(
 /// let mut runtime = std::ptr::null_mut();
 /// let mut error = svm_byte_array::default();
 ///
-/// let res = unsafe { svm_memory_runtime_create(&mut runtime, kv, host, imports, &mut error) };
+/// let res = unsafe { svm_memory_runtime_create(&mut runtime, kv, imports, &mut error) };
 /// assert!(res.is_ok());
 ///
 /// let bytes = svm_byte_array::default();
@@ -197,8 +192,6 @@ pub unsafe extern "C" fn svm_validate_app(
 /// use svm_runtime_c_api::*;
 /// use svm_types::Address;
 ///
-/// let mut host = std::ptr::null_mut();
-///
 /// // allocate imports
 /// let mut imports = testing::imports_alloc(0);
 ///
@@ -211,7 +204,7 @@ pub unsafe extern "C" fn svm_validate_app(
 /// let mut runtime = std::ptr::null_mut();
 /// let mut error = svm_byte_array::default();
 ///
-/// let res = unsafe { svm_memory_runtime_create(&mut runtime, kv, host, imports, &mut error) };
+/// let res = unsafe { svm_memory_runtime_create(&mut runtime, kv, imports, &mut error) };
 /// assert!(res.is_ok());
 ///
 /// let mut app_addr = svm_byte_array::default();
@@ -471,7 +464,6 @@ pub unsafe extern "C" fn svm_state_kv_destroy(kv: *mut c_void) -> svm_result_t {
 /// use svm_runtime_c_api::*;
 ///
 /// let mut runtime = std::ptr::null_mut();
-/// let host = std::ptr::null_mut();
 /// let mut imports = testing::imports_alloc(0);
 ///
 /// let mut kv = std::ptr::null_mut();
@@ -479,7 +471,7 @@ pub unsafe extern "C" fn svm_state_kv_destroy(kv: *mut c_void) -> svm_result_t {
 /// assert!(res.is_ok());
 ///
 /// let mut error = svm_byte_array::default();
-/// let res = unsafe { svm_memory_runtime_create(&mut runtime, kv, host, imports, &mut error) };
+/// let res = unsafe { svm_memory_runtime_create(&mut runtime, kv, imports, &mut error) };
 /// assert!(res.is_ok());
 /// ```
 ///
@@ -488,7 +480,6 @@ pub unsafe extern "C" fn svm_state_kv_destroy(kv: *mut c_void) -> svm_result_t {
 pub unsafe extern "C" fn svm_memory_runtime_create(
     runtime: *mut *mut c_void,
     state_kv: *mut c_void,
-    host: *mut c_void,
     imports: *const c_void,
     _error: *mut svm_byte_array,
 ) -> svm_result_t {
@@ -496,7 +487,7 @@ pub unsafe extern "C" fn svm_memory_runtime_create(
 
     let imports = helpers::cast_to_imports(imports);
     let state_kv = svm_common::from_raw_mut(state_kv);
-    let mem_runtime = svm_runtime::testing::create_memory_runtime(host, state_kv, imports.to_vec());
+    let mem_runtime = svm_runtime::testing::create_memory_runtime(state_kv, imports.to_vec());
 
     let res = box_runtime!(runtime, mem_runtime);
 
@@ -515,11 +506,10 @@ pub unsafe extern "C" fn svm_memory_runtime_create(
 ///
 /// let mut runtime = std::ptr::null_mut();
 /// let path = String::from("path goes here").into();
-/// let host = std::ptr::null_mut();
 /// let mut imports = testing::imports_alloc(0);
 /// let mut error = svm_byte_array::default();
 ///
-/// let res = unsafe { svm_runtime_create(&mut runtime, path, host, imports, &mut error) };
+/// let res = unsafe { svm_runtime_create(&mut runtime, path, imports, &mut error) };
 /// assert!(res.is_ok());
 /// ```
 ///
@@ -528,7 +518,6 @@ pub unsafe extern "C" fn svm_memory_runtime_create(
 pub unsafe extern "C" fn svm_runtime_create(
     runtime: *mut *mut c_void,
     kv_path: svm_byte_array,
-    host: *mut c_void,
     imports: *const c_void,
     error: *mut svm_byte_array,
 ) -> svm_result_t {
@@ -548,7 +537,7 @@ pub unsafe extern "C" fn svm_runtime_create(
         &Path,
         DefaultSerializerTypes,
         DefaultGasEstimator,
-    >(host, Path::new(&kv_path), imports.to_vec());
+    >(Path::new(&kv_path), imports.to_vec());
 
     let res = box_runtime!(runtime, rocksdb_runtime);
 
@@ -565,8 +554,6 @@ pub unsafe extern "C" fn svm_runtime_create(
 /// use svm_runtime_c_api::*;
 /// use svm_types::Address;
 ///
-/// let mut host = std::ptr::null_mut();
-///
 /// // allocate imports
 /// let mut imports = testing::imports_alloc(0);
 ///
@@ -577,7 +564,7 @@ pub unsafe extern "C" fn svm_runtime_create(
 ///
 /// let mut runtime = std::ptr::null_mut();
 /// let mut error = svm_byte_array::default();
-/// let res = unsafe { svm_memory_runtime_create(&mut runtime, state_kv, host, imports, &mut error) };
+/// let res = unsafe { svm_memory_runtime_create(&mut runtime, state_kv, imports, &mut error) };
 /// assert!(res.is_ok());
 ///
 /// // deploy template
@@ -646,13 +633,11 @@ pub unsafe extern "C" fn svm_deploy_template(
 /// use svm_runtime_c_api::*;
 /// use svm_types::Address;
 ///
-/// let mut host = std::ptr::null_mut();
-///
 /// // allocate imports
 /// let mut imports = testing::imports_alloc(0);
 ///
 /// // create runtime
-//
+///
 /// let mut state_kv = std::ptr::null_mut();
 /// let res = unsafe { svm_memory_state_kv_create(&mut state_kv) };
 /// assert!(res.is_ok());
@@ -660,7 +645,7 @@ pub unsafe extern "C" fn svm_deploy_template(
 /// let mut runtime = std::ptr::null_mut();
 /// let mut error = svm_byte_array::default();
 ///
-/// let res = unsafe { svm_memory_runtime_create(&mut runtime, state_kv, host, imports, &mut error) };
+/// let res = unsafe { svm_memory_runtime_create(&mut runtime, state_kv, imports, &mut error) };
 /// assert!(res.is_ok());
 ///
 /// let mut app_receipt = svm_byte_array::default();
@@ -729,8 +714,6 @@ pub unsafe extern "C" fn svm_spawn_app(
 /// use svm_runtime_c_api::*;
 /// use svm_types::{State, Address};
 ///
-/// let mut host = std::ptr::null_mut();
-///
 /// // allocate imports
 /// let mut imports = testing::imports_alloc(0);
 ///
@@ -743,7 +726,7 @@ pub unsafe extern "C" fn svm_spawn_app(
 /// let mut runtime = std::ptr::null_mut();
 /// let mut error = svm_byte_array::default();
 ///
-/// let res = unsafe { svm_memory_runtime_create(&mut runtime, state_kv, host, imports, &mut error) };
+/// let res = unsafe { svm_memory_runtime_create(&mut runtime, state_kv, imports, &mut error) };
 /// assert!(res.is_ok());
 ///
 /// let mut exec_receipt = svm_byte_array::default();
@@ -807,8 +790,6 @@ pub unsafe extern "C" fn svm_exec_app(
 /// use svm_runtime_c_api::*;
 /// use svm_types::Address;
 ///
-/// let mut host = std::ptr::null_mut();
-///
 /// // allocate imports
 /// let mut imports = testing::imports_alloc(0);
 ///
@@ -820,7 +801,7 @@ pub unsafe extern "C" fn svm_exec_app(
 ///
 /// let mut runtime = std::ptr::null_mut();
 /// let mut error = svm_byte_array::default();
-/// let res = unsafe { svm_memory_runtime_create(&mut runtime, state_kv, host, imports, &mut error) };
+/// let res = unsafe { svm_memory_runtime_create(&mut runtime, state_kv, imports, &mut error) };
 /// assert!(res.is_ok());
 ///
 /// // destroy runtime

--- a/crates/svm-runtime-c-api/tests/api_tests.rs
+++ b/crates/svm-runtime-c-api/tests/api_tests.rs
@@ -62,7 +62,6 @@ unsafe fn test_svm_runtime() {
     let gas_limit = 0;
 
     // 1) init runtime
-    let host = std::ptr::null_mut();
     let mut state_kv = std::ptr::null_mut();
     let mut runtime = std::ptr::null_mut();
     let imports = create_imports();
@@ -71,7 +70,7 @@ unsafe fn test_svm_runtime() {
     let res = api::svm_memory_state_kv_create(&mut state_kv);
     assert!(res.is_ok());
 
-    let res = api::svm_memory_runtime_create(&mut runtime, state_kv, host, imports, &mut error);
+    let res = api::svm_memory_runtime_create(&mut runtime, state_kv, imports, &mut error);
     assert!(res.is_ok());
 
     // 2) deploy app-template

--- a/crates/svm-runtime/src/context.rs
+++ b/crates/svm-runtime/src/context.rs
@@ -10,7 +10,6 @@ use svm_types::{gas::MaybeGas, receipt::Log};
 
 /// `Context` is a container for the accessible data by `wasmer` instances.
 ///
-/// * `host`         - A pointer to the `Host`.
 /// * `storage`      - Instance's `AppStorage`.
 /// * `gas_metering` - Whether gas metering is enabled.
 
@@ -20,21 +19,16 @@ pub struct Context {
 }
 
 impl Context {
-    pub fn new(host: *mut c_void, gas_limit: MaybeGas, storage: AppStorage) -> Self {
-        let inner = ContextInner::new(host, gas_limit, storage);
+    pub fn new(gas_limit: MaybeGas, storage: AppStorage) -> Self {
+        let inner = ContextInner::new(gas_limit, storage);
 
         Self {
             inner: Rc::new(RefCell::new(inner)),
         }
     }
 
-    pub fn new_with_memory(
-        memory: Memory,
-        host: *mut c_void,
-        gas_limit: MaybeGas,
-        storage: AppStorage,
-    ) -> Self {
-        let ctx = Self::new(host, gas_limit, storage);
+    pub fn new_with_memory(memory: Memory, gas_limit: MaybeGas, storage: AppStorage) -> Self {
+        let ctx = Self::new(gas_limit, storage);
 
         ctx.borrow_mut().set_memory(memory);
 
@@ -53,11 +47,6 @@ impl Context {
 }
 
 pub struct ContextInner {
-    /// A pointer to the `host`.
-    ///
-    /// For example, `host` will point a to struct having an access to the balance of each account.
-    pub host: *mut c_void,
-
     /// Gas limit (relevant only when `gas_metering = true`)
     pub gas_limit: u64,
 
@@ -81,13 +70,12 @@ pub struct ContextInner {
 }
 
 impl ContextInner {
-    fn new(host: *mut c_void, gas_limit: MaybeGas, storage: AppStorage) -> Self {
+    fn new(gas_limit: MaybeGas, storage: AppStorage) -> Self {
         let gas_metering = gas_limit.is_some();
         let gas_limit = gas_limit.unwrap_or(0);
         let logs = Vec::new();
 
         Self {
-            host,
             storage,
             gas_metering,
             gas_limit,

--- a/crates/svm-runtime/src/runtime/default.rs
+++ b/crates/svm-runtime/src/runtime/default.rs
@@ -35,9 +35,6 @@ pub struct DefaultRuntime<ENV, GE> {
     /// The runtime environment. Used mainly for managing app persistence.
     pub env: ENV,
 
-    /// A raw pointer to host (a.k.a the `Full-Node` in the realm of Blockchain).
-    pub host: *mut c_void,
-
     /// The runtime configuration
     pub config: Config,
 
@@ -167,7 +164,6 @@ where
 {
     /// Initializes a new `DefaultRuntime`.
     pub fn new<P: AsRef<Path>>(
-        host: *mut c_void,
         env: ENV,
         kv_path: P,
         imports: Vec<Import>,
@@ -177,7 +173,6 @@ where
 
         Self {
             env,
-            host,
             config,
             imports,
             storage_builder,
@@ -529,7 +524,7 @@ where
         let layout = &template.data;
         let storage = self.open_app_storage(app_addr, state, layout);
 
-        Context::new(self.host, gas_limit, storage)
+        Context::new(gas_limit, storage)
     }
 
     fn create_import_object(&self, store: &Store, ctx: &Context) -> ImportObject {

--- a/crates/svm-runtime/src/runtime/rocksdb.rs
+++ b/crates/svm-runtime/src/runtime/rocksdb.rs
@@ -13,7 +13,6 @@ use wasmer::Export;
 
 /// Creates a new `Runtime` backed by `rocksdb` for persistence.
 pub fn create_rocksdb_runtime<P, S, GE>(
-    host: *mut c_void,
     kv_path: P,
     imports: Vec<Import>,
 ) -> DefaultRuntime<RocksdbEnv<S>, GE>
@@ -24,7 +23,7 @@ where
 {
     let env = app_env_build(&kv_path);
 
-    DefaultRuntime::new(host, env, kv_path, imports, Box::new(app_storage_build))
+    DefaultRuntime::new(env, kv_path, imports, Box::new(app_storage_build))
 }
 
 fn app_env_build<P, S>(kv_path: &P) -> RocksdbEnv<S>

--- a/crates/svm-runtime/src/testing.rs
+++ b/crates/svm-runtime/src/testing.rs
@@ -93,9 +93,8 @@ pub fn memory_state_kv_init() -> Rc<RefCell<dyn StatefulKV>> {
     Rc::new(RefCell::new(FakeKV::new()))
 }
 
-/// Creates an in-memory `Runtime` backed by key-value, raw pointer to host and host vmcalls (`imports`)
+/// Creates an in-memory `Runtime` backed by key-value and host vmcalls (`imports`).
 pub fn create_memory_runtime(
-    host: *mut c_void,
     state_kv: &Rc<RefCell<dyn StatefulKV>>,
     imports: Vec<Import>,
 ) -> DefaultRuntime<DefaultMemoryEnv, DefaultGasEstimator> {
@@ -104,7 +103,7 @@ pub fn create_memory_runtime(
     let env = runtime_memory_env_builder();
     let kv_path = Path::new("mem");
 
-    DefaultRuntime::new(host, env, &kv_path, imports, Box::new(storage_builder))
+    DefaultRuntime::new(env, &kv_path, imports, Box::new(storage_builder))
 }
 
 /// Returns a function (wrapped inside `Box`) that initializes an App's storage client.

--- a/crates/svm-runtime/tests/runtime_tests.rs
+++ b/crates/svm-runtime/tests/runtime_tests.rs
@@ -19,10 +19,9 @@ macro_rules! default_runtime {
 
         let state_kv = testing::memory_state_kv_init();
 
-        let host = std::ptr::null_mut();
         let imports = Vec::new();
 
-        testing::create_memory_runtime(host, &state_kv, imports)
+        testing::create_memory_runtime(&state_kv, imports)
     }};
 }
 

--- a/crates/svm-runtime/tests/vmcalls_tests.rs
+++ b/crates/svm-runtime/tests/vmcalls_tests.rs
@@ -95,13 +95,12 @@ fn vmcalls_empty_wasm() {
 #[test]
 fn vmcalls_get32_set32() {
     let app_addr = Address::of("my-app");
-    let host: *mut c_void = std::ptr::null_mut();
     let gas_limit = MaybeGas::new();
     let layout: DataLayout = vec![4, 2].into();
 
     let store = testing::wasmer_store();
     let storage = testing::blank_storage(&app_addr, &layout);
-    let ctx = Context::new(host, gas_limit, storage);
+    let ctx = Context::new(gas_limit, storage);
 
     let import_object = imports! {
         "svm" => {
@@ -130,13 +129,12 @@ fn vmcalls_get32_set32() {
 #[test]
 fn vmcalls_get64_set64() {
     let app_addr = Address::of("my-app");
-    let host: *mut c_void = std::ptr::null_mut();
     let gas_limit = MaybeGas::new();
     let layout: DataLayout = vec![4, 2].into();
 
     let store = testing::wasmer_store();
     let storage = testing::blank_storage(&app_addr, &layout);
-    let ctx = Context::new(host, gas_limit, storage);
+    let ctx = Context::new(gas_limit, storage);
 
     let import_object = imports! {
         "svm" => {
@@ -165,14 +163,13 @@ fn vmcalls_get64_set64() {
 #[test]
 fn vmcalls_load160() {
     let app_addr = Address::of("11223344556677889900");
-    let host: *mut c_void = std::ptr::null_mut();
     let gas_limit = MaybeGas::new();
     let layout: DataLayout = vec![20].into();
 
     let store = testing::wasmer_store();
     let memory = testing::wasmer_memory(&store);
     let storage = testing::blank_storage(&app_addr, &layout);
-    let ctx = Context::new_with_memory(memory.clone(), host, gas_limit, storage);
+    let ctx = Context::new_with_memory(memory.clone(), gas_limit, storage);
 
     let import_object = imports! {
         "svm" => {
@@ -209,14 +206,13 @@ fn vmcalls_load160() {
 #[test]
 fn vmcalls_store160() {
     let app_addr = Address::of("11223344556677889900");
-    let host: *mut c_void = std::ptr::null_mut();
     let gas_limit = MaybeGas::new();
     let layout: DataLayout = vec![20].into();
 
     let store = testing::wasmer_store();
     let memory = testing::wasmer_memory(&store);
     let storage = testing::blank_storage(&app_addr, &layout);
-    let ctx = Context::new_with_memory(memory.clone(), host, gas_limit, storage);
+    let ctx = Context::new_with_memory(memory.clone(), gas_limit, storage);
 
     let import_object = imports! {
         "svm" => {
@@ -249,14 +245,13 @@ fn vmcalls_store160() {
 #[test]
 fn vmcalls_log() {
     let app_addr = Address::of("my-app");
-    let host: *mut c_void = std::ptr::null_mut();
     let gas_limit = MaybeGas::new();
     let layout = DataLayout::empty();
 
     let store = testing::wasmer_store();
     let memory = testing::wasmer_memory(&store);
     let storage = testing::blank_storage(&app_addr, &layout);
-    let ctx = Context::new_with_memory(memory.clone(), host, gas_limit, storage);
+    let ctx = Context::new_with_memory(memory.clone(), gas_limit, storage);
 
     let import_object = imports! {
         "svm" => {


### PR DESCRIPTION
Removed `host` raw pointer from the runtime context, which is no longer intended to be passed to the host import function.
