### PR TITLE
`svm_encode_spawn_app` to support `name`

### DIFF
--- a/crates/svm-runtime-c-api/src/api.rs
+++ b/crates/svm-runtime-c-api/src/api.rs
@@ -1139,6 +1139,7 @@ pub unsafe extern "C" fn svm_encode_spawn_app(
     spawn_app: *mut svm_byte_array,
     version: u32,
     template_addr: svm_byte_array,
+    name: svm_byte_array,
     ctor_name: svm_byte_array,
     calldata: svm_byte_array,
     error: *mut svm_byte_array,
@@ -1155,11 +1156,13 @@ pub unsafe extern "C" fn svm_encode_spawn_app(
     let template_addr = template_addr.unwrap();
 
     // TODO: return an error instead of `unwrap()`
+    let name = String::try_from(name).unwrap();
     let ctor_name = String::try_from(ctor_name).unwrap();
 
     let mut bytes = SpawnAppBuilder::new()
         .with_version(version)
         .with_template(&template_addr.into())
+        .with_name(&name)
         .with_ctor(&ctor_name)
         .with_calldata(&calldata)
         .build();


### PR DESCRIPTION
The missing field is causing a panic. 

```
thread '<unnamed>' panicked at 'called `Option::unwrap()` on a `None` value', crates/svm-codec/src/api/builder/app_builder.rs:89:30
```