### PR TITLE
using feature flags for faster compilation.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,13 +43,13 @@ jobs:
       with:
         toolchain: nightly
         command: build
-        args: ${{ matrix.release }} --all
+        args: ${{ matrix.release }} --all --features=default-memory,default-rocksdb
     - name: Cargo Test
       uses: actions-rs/cargo@v1
       with:
         toolchain: nightly
         command: test
-        args: ${{ matrix.release }} --all 
+        args: ${{ matrix.release }} --all --features=default-memory
     - name: Setup node
       uses: actions/setup-node@v1
       with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,9 +52,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
-version = "0.3.54"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2baad346b2d4e94a24347adeee9c7a93f412ee94b9cc26e5b59dea23848e9f28"
+checksum = "ef5140344c85b01f9bbb4d4b7288a8aa4b3287ccef913a14bcc78a1063623598"
 dependencies = [
  "addr2line",
  "cfg-if 1.0.0",
@@ -76,9 +76,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.53.1"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99de13bb6361e01e493b3db7928085dcc474b7ba4f5481818e53a89d76b8393f"
+checksum = "66c0bb6167449588ff70803f4127f0684f9063097eca5016f37eb52b92c2cf36"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -100,9 +100,9 @@ dependencies = [
 
 [[package]]
 name = "bit-vec"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0dc55f2d8a1a85650ac47858bb001b4c0dd73d79e3c455a842925e68d29cd3"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
@@ -137,18 +137,18 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.62"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1770ced377336a88a67c473594ccc14eca6f4559217c34f64aac8f83d641b40"
+checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
 dependencies = [
  "jobserver",
 ]
 
 [[package]]
 name = "cexpr"
-version = "0.3.6"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fce5b5fb86b0c57c20c834c1b412fd09c77c8a59b9473f86272709e78874cd1d"
+checksum = "f4aedb84272dbe89af497cf81375129abda4fc0a9e7c5d317498c15cc30c0d27"
 dependencies = [
  "nom",
 ]
@@ -167,9 +167,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clang-sys"
-version = "0.28.1"
+version = "0.29.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81de550971c976f176130da4b2978d3b524eaa0fd9ac31f3ceb5ae1231fb4853"
+checksum = "fe6837df1d5cba2397b835c8530f51723267e16abbf83892e9e5af4f0e5dd10a"
 dependencies = [
  "glob 0.3.0",
  "libc",
@@ -193,18 +193,18 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.44"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e56268c17a6248366d66d4a47a3381369d068cce8409bb1716ed77ea32163bb"
+checksum = "eb6210b637171dfba4cda12e579ac6dc73f5165ad56133e5d72ef3131f320855"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "const_fn"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c478836e029dcef17fb47c89023448c64f781a046e0300e257ad8225ae59afab"
+checksum = "cd51eab21ab4fd6a3bf889e2d0958c0a6e3a61ad04260325e919e652a2a62826"
 
 [[package]]
 name = "cranelift-bforest"
@@ -303,27 +303,26 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0f606a85340376eef0d6d8fec399e6d4a544d648386c6645eb6d0653b27d9f"
+checksum = "a1aaa739f95311c2c7887a76863f500026092fb1dce0161dab577e559ef3569d"
 dependencies = [
  "cfg-if 1.0.0",
  "const_fn",
  "crossbeam-utils",
  "lazy_static",
- "memoffset 0.5.6",
+ "memoffset",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec91540d98355f690a86367e566ecad2e9e579f230230eb7c21398372be73ea5"
+checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
 dependencies = [
  "autocfg",
  "cfg-if 1.0.0",
- "const_fn",
  "lazy_static",
 ]
 
@@ -540,9 +539,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55e2e4c765aa53a0424761bf9f41aa7a6ac1efa87238f59560640e27fca028f2"
+checksum = "4fb1fa934250de4de8aef298d81c729a7d33d8c239daa3a7575e6b92bfc7313b"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -584,9 +583,9 @@ checksum = "3576a87f2ba00f6f106fdfcd16db1d698d648a26ad8e0573cad8537c3c362d2a"
 
 [[package]]
 name = "libc"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
+checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
 
 [[package]]
 name = "libloading"
@@ -600,9 +599,9 @@ dependencies = [
 
 [[package]]
 name = "libloading"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1090080fe06ec2648d0da3881d9453d97e71a45f00eb179af7fdd7e3f686fdb0"
+checksum = "e9367bdfa836b7e3cf895867f7a570283444da90562980ec2263d6e1569b16bc"
 dependencies = [
  "cfg-if 1.0.0",
  "winapi",
@@ -610,9 +609,9 @@ dependencies = [
 
 [[package]]
 name = "librocksdb-sys"
-version = "6.7.4"
+version = "6.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "883213ae3d09bfc3d104aefe94b25ebb183b6f4d3a515b23b14817e1f4854005"
+checksum = "eb5b56f651c204634b936be2f92dbb42c36867e00ff7fe2405591f3b9fa66f09"
 dependencies = [
  "bindgen",
  "cc",
@@ -662,15 +661,6 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "memoffset"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "157b4208e3059a8f9e78d559edc658e13df41410cb3ae03979c83130067fdd87"
@@ -696,12 +686,12 @@ checksum = "0debeb9fcf88823ea64d64e4a815ab1643f33127d995978e099942ce38f25238"
 
 [[package]]
 name = "nom"
-version = "4.2.3"
+version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
+checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
 dependencies = [
  "memchr",
- "version_check 0.1.5",
+ "version_check",
 ]
 
 [[package]]
@@ -766,9 +756,9 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.1.11"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c917123afa01924fc84bb20c4c03f004d9c38e5127e3c039bbf7f4b9c76a2f6b"
+checksum = "6b063f57ec186e6140e2b8b6921e5f1bd89c7356dda5b33acc5401203ca6131c"
 
 [[package]]
 name = "ppv-lite86"
@@ -786,7 +776,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "version_check 0.9.2",
+ "version_check",
 ]
 
 [[package]]
@@ -797,7 +787,7 @@ checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
  "proc-macro2",
  "quote",
- "version_check 0.9.2",
+ "version_check",
 ]
 
 [[package]]
@@ -1023,9 +1013,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.117"
+version = "1.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b88fa983de7720629c9387e9f517353ed404164b1e482c970a90c1a4aaf7dc1a"
+checksum = "06c64263859d87aa2eb554587e2d23183398d617427327cf2b3d0ed8c69e4800"
 dependencies = [
  "serde_derive",
 ]
@@ -1041,9 +1031,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.117"
+version = "1.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbd1ae72adb44aab48f325a02444a5fc079349a8d804c1fc922aed3f7454c74e"
+checksum = "c84d3526699cd55261af4b941e4e725444df67aa4f9e6a3564f18030d12672df"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1052,9 +1042,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.59"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcac07dbffa1c65e7f816ab9eba78eb142c6d44410f4eeba1e26e4f5dfa56b95"
+checksum = "1500e84d27fe482ed1dc791a56eddc2f230046a040fa908c08bda1d9fb615779"
 dependencies = [
  "itoa",
  "ryu",
@@ -1069,9 +1059,9 @@ checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 
 [[package]]
 name = "smallvec"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7acad6f34eb9e8a259d3283d1e8c1d34d7415943d4895f65cc73813c7396fc85"
+checksum = "ae524f056d7d770e174287294f562e95044c68e88dec909a00d2094805db9d75"
 
 [[package]]
 name = "stable_deref_trait"
@@ -1373,9 +1363,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.48"
+version = "1.0.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc371affeffc477f42a221a1e4297aedcea33d47d19b61455588bd9d8f6b19ac"
+checksum = "9a2af957a63d6bd42255c359c93d9bfdb97076bd3b820897ce55ffbfbf107f44"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1404,9 +1394,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
 ]
@@ -1469,11 +1459,11 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0987850db3733619253fe60e17cb59b82d37c7e6c0236bb81e4d6b87c879f27"
+checksum = "9f47026cdc4080c07e49b37087de021820269d996f581aac150ef9e5583eefe3"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -1501,9 +1491,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8716a166f290ff49dabc18b44aa407cb7c6dbe1aa0971b44b8a24b0ca35aae"
+checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
 
 [[package]]
 name = "unicode-width"
@@ -1522,12 +1512,6 @@ name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-
-[[package]]
-name = "version_check"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 
 [[package]]
 name = "version_check"
@@ -1702,7 +1686,7 @@ dependencies = [
  "bincode",
  "cfg-if 0.1.10",
  "leb128",
- "libloading 0.6.5",
+ "libloading 0.6.6",
  "serde",
  "tempfile",
  "tracing",
@@ -1747,7 +1731,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "indexmap",
  "libc",
- "memoffset 0.6.1",
+ "memoffset",
  "more-asserts",
  "region",
  "serde",
@@ -1764,18 +1748,18 @@ checksum = "87cc2fe6350834b4e528ba0901e7aa405d78b89dc1fa3145359eb4de0e323fcf"
 
 [[package]]
 name = "wast"
-version = "27.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2c3ef5f6a72dffa44c24d5811123f704e18a1dbc83637d347b1852b41d3835c"
+checksum = "9b79907b22f740634810e882d8d1d9d0f9563095a8ab94e786e370242bff5cd2"
 dependencies = [
  "leb128",
 ]
 
 [[package]]
 name = "wat"
-version = "1.0.28"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "835cf59c907f67e2bbc20f50157e08f35006fe2a8444d8ec9f5683e22f937045"
+checksum = "a8279a02835bf12e61ed2b3c3cbc6ecf9918762fd97e036917c11a09ec20ca44"
 dependencies = [
  "wast",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,32 +374,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b72465f46d518f6015d9cf07f7f3013a95dd6b9c2747c3d65ae0cce43929d14f"
 
 [[package]]
-name = "dynasm"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62a59fbab09460c1569eeea9b5e4cf62f13f5198b1c2ba0e5196dd7fdd17cd42"
-dependencies = [
- "bitflags",
- "byteorder",
- "lazy_static",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "dynasmrt"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85bec3edae2841d37b1c3dc7f3fd403c9061f26e9ffeeee97a3ea909b1bb2ef1"
-dependencies = [
- "byteorder",
- "dynasm",
- "memmap",
-]
-
-[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -648,16 +622,6 @@ name = "memchr"
 version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
-
-[[package]]
-name = "memmap"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
-dependencies = [
- "libc",
- "winapi",
-]
 
 [[package]]
 name = "memoffset"
@@ -1190,7 +1154,6 @@ dependencies = [
  "svm-common",
  "wasmer",
  "wasmer-compiler",
- "wasmparser",
  "wat",
 ]
 
@@ -1561,7 +1524,6 @@ dependencies = [
  "thiserror",
  "wasmer-compiler",
  "wasmer-compiler-cranelift",
- "wasmer-compiler-singlepass",
  "wasmer-derive",
  "wasmer-engine",
  "wasmer-engine-jit",
@@ -1603,25 +1565,6 @@ dependencies = [
  "serde",
  "smallvec",
  "tracing",
- "wasmer-compiler",
- "wasmer-types",
- "wasmer-vm",
-]
-
-[[package]]
-name = "wasmer-compiler-singlepass"
-version = "1.0.0-beta1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdcb01d834ce3a8556ea487813d9f05159170c212c6789f52cc18a467b27f9ca"
-dependencies = [
- "byteorder",
- "dynasm",
- "dynasmrt",
- "lazy_static",
- "more-asserts",
- "rayon",
- "serde",
- "smallvec",
  "wasmer-compiler",
  "wasmer-types",
  "wasmer-vm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -375,6 +375,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b72465f46d518f6015d9cf07f7f3013a95dd6b9c2747c3d65ae0cce43929d14f"
 
 [[package]]
+name = "dynasm"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62a59fbab09460c1569eeea9b5e4cf62f13f5198b1c2ba0e5196dd7fdd17cd42"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "lazy_static",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "dynasmrt"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bec3edae2841d37b1c3dc7f3fd403c9061f26e9ffeeee97a3ea909b1bb2ef1"
+dependencies = [
+ "byteorder",
+ "dynasm",
+ "memmap",
+]
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -623,6 +649,16 @@ name = "memchr"
 version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+
+[[package]]
+name = "memmap"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "memoffset"
@@ -1541,6 +1577,7 @@ dependencies = [
  "thiserror",
  "wasmer-compiler",
  "wasmer-compiler-cranelift",
+ "wasmer-compiler-singlepass",
  "wasmer-derive",
  "wasmer-engine",
  "wasmer-engine-jit",
@@ -1582,6 +1619,25 @@ dependencies = [
  "serde",
  "smallvec",
  "tracing",
+ "wasmer-compiler",
+ "wasmer-types",
+ "wasmer-vm",
+]
+
+[[package]]
+name = "wasmer-compiler-singlepass"
+version = "1.0.0-beta1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdcb01d834ce3a8556ea487813d9f05159170c212c6789f52cc18a467b27f9ca"
+dependencies = [
+ "byteorder",
+ "dynasm",
+ "dynasmrt",
+ "lazy_static",
+ "more-asserts",
+ "rayon",
+ "serde",
+ "smallvec",
  "wasmer-compiler",
  "wasmer-types",
  "wasmer-vm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ features = ["lz4"]
 [dependencies.wasmer]
 version="1.0.0-beta1"
 default-features = false
-features = ["default-cranelift", "default-jit"]
 
 [dependencies]
 libc = "0.2"
@@ -38,7 +37,7 @@ log = "0.4"
 lazy_static = "1.4.0"
 hex = "0.4"
 svm-common = { path = "crates/svm-common" }
-svm-kv = { path = "crates/svm-kv" }
+svm-kv = { path = "crates/svm-kv", default-features = false }
 svm-gas = { path = "crates/svm-gas" }
 svm-app-query = { path = "crates/svm-app-query" }
 svm-types = { path = "crates/svm-types" }
@@ -52,10 +51,10 @@ svm-nibble = { path = "crates/svm-nibble" }
 svm-codec = { path = "crates/svm-codec" }
 svm-layout = { path = "crates/svm-layout" }
 svm-storage = { path = "crates/svm-storage" }
-svm-compiler = { path = "crates/svm-compiler" }
-svm-runtime = { path = "crates/svm-runtime" }
+svm-compiler = { path = "crates/svm-compiler", default-features = false }
+svm-runtime = { path = "crates/svm-runtime", default-features = false }
 svm-ffi = { path = "crates/svm-ffi" }
-svm-runtime-c-api = { path = "crates/svm-runtime-c-api" }
+svm-runtime-c-api = { path = "crates/svm-runtime-c-api", default-features = false }
 svm-abi-layout = { path = "crates/svm-abi/layout" }
 svm-abi-encoder = { path = "crates/svm-abi/encoder" }
 svm-abi-decoder = { path = "crates/svm-abi/decoder" }
@@ -89,3 +88,8 @@ members = [
   "crates/svm-ffi",
   "crates/svm-runtime-c-api",
 ]
+
+[features]
+default = ["default-memory"]
+default-memory = ["svm-runtime-c-api/default-memory", "svm-runtime/default-memory", "svm-kv/default-memory"]
+default-rocksdb = ["svm-runtime-c-api/default-rocksdb", "svm-runtime/default-rocksdb", "svm-kv/default-rocksdb"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,9 +25,15 @@ optional = true
 version = "0.12.4"
 features = ["lz4"]
 
-[dependencies.wasmer]
+[target.'cfg(unix)'.dependencies.wasmer]
 version="1.0.0-beta1"
 default-features = false
+features = ["singlepass", "default-jit"]
+
+[target.'cfg(windows)'.dependencies.wasmer]
+version="1.0.0-beta1"
+default-features = false
+features = ["default-cranelift", "default-jit"]
 
 [dependencies]
 libc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,12 +25,7 @@ optional = true
 version = "0.12.4"
 features = ["lz4"]
 
-[target.'cfg(unix)'.dependencies.wasmer]
-version="1.0.0-beta1"
-default-features = false
-features = ["singlepass", "default-jit"]
-
-[target.'cfg(windows)'.dependencies.wasmer]
+[dependencies.wasmer]
 version="1.0.0-beta1"
 default-features = false
 features = ["default-cranelift", "default-jit"]
@@ -56,7 +51,7 @@ svm-sdk = { path = "crates/svm-sdk" }
 svm-nibble = { path = "crates/svm-nibble" }
 svm-codec = { path = "crates/svm-codec" }
 svm-layout = { path = "crates/svm-layout" }
-svm-storage = { path = "crates/svm-storage" }
+svm-storage = { path = "crates/svm-storage", default-features = false }
 svm-compiler = { path = "crates/svm-compiler", default-features = false }
 svm-runtime = { path = "crates/svm-runtime", default-features = false }
 svm-ffi = { path = "crates/svm-ffi" }

--- a/crates/svm-compiler/Cargo.toml
+++ b/crates/svm-compiler/Cargo.toml
@@ -17,19 +17,10 @@ version = "0.0.0"
 [dependencies.wasmer-compiler]
 version="1.0.0-beta1"
 
-[dependencies.wasmparser]
-version = "0.65"
-default-features = false
-
-[dev-dependencies]
-wat = "1.0"
-
-[target.'cfg(unix)'.dependencies.wasmer]
-version="1.0.0-beta1"
-default-features = false
-features = ["singlepass", "default-jit"]
-
-[target.'cfg(windows)'.dependencies.wasmer]
+[dependencies.wasmer]
 version="1.0.0-beta1"
 default-features = false
 features = ["default-cranelift", "default-jit"]
+
+[dev-dependencies]
+wat = "1.0"

--- a/crates/svm-compiler/Cargo.toml
+++ b/crates/svm-compiler/Cargo.toml
@@ -14,10 +14,6 @@ publish = false
 path = "../svm-common"
 version = "0.0.0"
 
-[dependencies.wasmer]
-version="1.0.0-beta1"
-default-features = false
-
 [dependencies.wasmer-compiler]
 version="1.0.0-beta1"
 
@@ -28,7 +24,12 @@ default-features = false
 [dev-dependencies]
 wat = "1.0"
 
-[features]
-default = ["singlepass"]
-singlepass = ["wasmer/singlepass", "wasmer/default-jit"]
-cranelift = ["wasmer/default-cranelift", "wasmer/default-jit"]
+[target.'cfg(unix)'.dependencies.wasmer]
+version="1.0.0-beta1"
+default-features = false
+features = ["singlepass", "default-jit"]
+
+[target.'cfg(windows)'.dependencies.wasmer]
+version="1.0.0-beta1"
+default-features = false
+features = ["default-cranelift", "default-jit"]

--- a/crates/svm-compiler/Cargo.toml
+++ b/crates/svm-compiler/Cargo.toml
@@ -17,7 +17,6 @@ version = "0.0.0"
 [dependencies.wasmer]
 version="1.0.0-beta1"
 default-features = false
-features = ["default-cranelift", "default-jit"]
 
 [dependencies.wasmer-compiler]
 version="1.0.0-beta1"
@@ -28,3 +27,8 @@ default-features = false
 
 [dev-dependencies]
 wat = "1.0"
+
+[features]
+default = ["singlepass"]
+singlepass = ["wasmer/singlepass", "wasmer/default-jit"]
+cranelift = ["wasmer/default-cranelift", "wasmer/default-jit"]

--- a/crates/svm-compiler/src/compiler.rs
+++ b/crates/svm-compiler/src/compiler.rs
@@ -1,4 +1,4 @@
-use wasmer::{Cranelift, Module, Store, JIT};
+use wasmer::{Module, Store, JIT};
 use wasmer_compiler::CompileError;
 
 /// Compiles the SVM app
@@ -20,6 +20,11 @@ pub fn compile(
 /// New fresh `Store`
 #[must_use]
 pub fn new_store() -> Store {
-    let engine = JIT::new(&Cranelift::default()).engine();
+    #[cfg(feature = "cranelift")]
+    let engine = JIT::new(&wasmer::Cranelift::default()).engine();
+
+    #[cfg(feature = "singlepass")]
+    let engine = JIT::new(&wasmer::Singlepass::default()).engine();
+
     Store::new(&engine)
 }

--- a/crates/svm-compiler/src/compiler.rs
+++ b/crates/svm-compiler/src/compiler.rs
@@ -20,11 +20,7 @@ pub fn compile(
 /// New fresh `Store`
 #[must_use]
 pub fn new_store() -> Store {
-    #[cfg(windows)]
     let engine = JIT::new(&wasmer::Cranelift::default()).engine();
-
-    #[cfg(unix)]
-    let engine = JIT::new(&wasmer::Singlepass::default()).engine();
 
     Store::new(&engine)
 }

--- a/crates/svm-compiler/src/compiler.rs
+++ b/crates/svm-compiler/src/compiler.rs
@@ -20,10 +20,10 @@ pub fn compile(
 /// New fresh `Store`
 #[must_use]
 pub fn new_store() -> Store {
-    #[cfg(feature = "cranelift")]
+    #[cfg(windows)]
     let engine = JIT::new(&wasmer::Cranelift::default()).engine();
 
-    #[cfg(feature = "singlepass")]
+    #[cfg(unix)]
     let engine = JIT::new(&wasmer::Singlepass::default()).engine();
 
     Store::new(&engine)

--- a/crates/svm-kv/Cargo.toml
+++ b/crates/svm-kv/Cargo.toml
@@ -14,12 +14,12 @@ path = "../svm-common"
 path = "../svm-types"
 
 [dependencies.db-key]
-optional = true
 version = "0.0.5"
+optional = true
 
 [dependencies.rocksdb]
-optional = true
 version = "0.12.4"
+optional = true
 default-features = false
 features = ["lz4"]
 

--- a/crates/svm-kv/Cargo.toml
+++ b/crates/svm-kv/Cargo.toml
@@ -30,6 +30,6 @@ log = "0.4"
 env_logger = "0.7.0"
 
 [features]
-default = ["memory", "default-rocksdb"]
-memory = []
+default = ["default-memory"]
+default-memory = []
 default-rocksdb = ["rocksdb"]

--- a/crates/svm-kv/src/lib.rs
+++ b/crates/svm-kv/src/lib.rs
@@ -12,7 +12,7 @@ pub mod traits;
 pub mod key;
 
 /// An in-memory implementation for `KVStore`
-#[cfg(feature = "memory")]
+#[cfg(feature = "default-memory")]
 pub mod memory;
 
 /// `KVStore` backed by rocksdb

--- a/crates/svm-runtime-c-api/Cargo.toml
+++ b/crates/svm-runtime-c-api/Cargo.toml
@@ -36,3 +36,8 @@ svm-abi-encoder = { path = "../svm-abi/encoder" }
 
 [build-dependencies]
 cbindgen = "0.15.0"
+
+[features]
+default = ["default-memory"]
+default-memory = ["svm-runtime/default-memory", "svm-kv/default-memory"]
+default-rocksdb = ["svm-runtime/default-rocksdb",  "svm-kv/default-rocksdb"]

--- a/crates/svm-runtime-c-api/Cargo.toml
+++ b/crates/svm-runtime-c-api/Cargo.toml
@@ -25,7 +25,7 @@ svm-codec = { path = "../svm-codec" }
 svm-gas = { path = "../svm-gas" }
 svm-layout = { path = "../svm-layout" }
 svm-storage = { path = "../svm-storage" }
-svm-compiler = { path = "../svm-compiler", default-features = false, features = [] }
+svm-compiler = { path = "../svm-compiler" }
 
 [dev-dependencies]
 wabt = "0.7.4"

--- a/crates/svm-runtime-c-api/Cargo.toml
+++ b/crates/svm-runtime-c-api/Cargo.toml
@@ -18,13 +18,13 @@ log = "0.4"
 byteorder = "1.3.2"
 svm-runtime = { path = "../svm-runtime", default-features = false }
 svm-common = { path = "../svm-common" }
-svm-kv = { path = "../svm-kv" }
+svm-kv = { path = "../svm-kv", default-features = false }
 svm-ffi = { path = "../svm-ffi" }
 svm-types = { path = "../svm-types" }
 svm-codec = { path = "../svm-codec" }
 svm-gas = { path = "../svm-gas" }
 svm-layout = { path = "../svm-layout" }
-svm-storage = { path = "../svm-storage" }
+svm-storage = { path = "../svm-storage", default-features = false }
 svm-compiler = { path = "../svm-compiler" }
 
 [dev-dependencies]
@@ -39,5 +39,5 @@ cbindgen = "0.15.0"
 
 [features]
 default = ["default-memory"]
-default-memory = ["svm-runtime/default-memory", "svm-kv/default-memory"]
-default-rocksdb = ["svm-runtime/default-rocksdb",  "svm-kv/default-rocksdb"]
+default-memory = ["svm-runtime/default-memory", "svm-kv/default-memory", "svm-storage/default-memory"]
+default-rocksdb = ["svm-runtime/default-rocksdb",  "svm-kv/default-rocksdb", "svm-storage/default-rocksdb"]

--- a/crates/svm-runtime-c-api/src/api.rs
+++ b/crates/svm-runtime-c-api/src/api.rs
@@ -569,6 +569,7 @@ pub unsafe extern "C" fn svm_memory_runtime_create(
 /// assert!(res.is_ok());
 /// ```
 ///
+#[cfg(feature = "default-rocksdb")]
 #[must_use]
 #[no_mangle]
 pub unsafe extern "C" fn svm_runtime_create(

--- a/crates/svm-runtime-c-api/src/lib.rs
+++ b/crates/svm-runtime-c-api/src/lib.rs
@@ -15,13 +15,15 @@ mod result;
 
 pub(crate) use error::{raw_error, raw_io_error, raw_utf8_error, raw_validate_error};
 
+#[cfg(feature = "default-rocksdb")]
+pub use api::svm_runtime_create;
+
 /// `SVM` FFI Interface
 #[rustfmt::skip]
 pub use api::{
     // Runtime
     svm_exec_app,
     svm_deploy_template,
-    svm_runtime_create,
     svm_spawn_app,
     
     // Gas Estimations

--- a/crates/svm-runtime/Cargo.toml
+++ b/crates/svm-runtime/Cargo.toml
@@ -6,9 +6,15 @@ license = "MIT"
 edition = "2018"
 publish = false
 
-[dependencies.wasmer]
+[target.'cfg(unix)'.dependencies.wasmer]
 version="1.0.0-beta1"
 default-features = false
+features = ["singlepass", "default-jit"]
+
+[target.'cfg(windows)'.dependencies.wasmer]
+version="1.0.0-beta1"
+default-features = false
+features = ["default-cranelift", "default-jit"]
 
 [dependencies]
 log = "0.4"

--- a/crates/svm-runtime/Cargo.toml
+++ b/crates/svm-runtime/Cargo.toml
@@ -9,7 +9,6 @@ publish = false
 [dependencies.wasmer]
 version="1.0.0-beta1"
 default-features = false
-features = ["default-cranelift", "default-jit"]
 
 [dependencies]
 log = "0.4"
@@ -19,7 +18,7 @@ wat = "1.0"
 svm-ffi = { path = "../svm-ffi" }
 svm-common = { path = "../svm-common" }
 svm-types = { path = "../svm-types" }
-svm-kv = { path = "../svm-kv" }
+svm-kv = { path = "../svm-kv", default-features = false }
 svm-layout = { path = "../svm-layout" }
 svm-storage = { path = "../svm-storage" }
 svm-nibble = { path = "../svm-nibble" }
@@ -32,3 +31,8 @@ maplit = "1.0.2"
 svm-sdk = { path = "../svm-sdk" }
 svm-abi-encoder = { path = "../svm-abi/encoder" }
 svm-abi-decoder = { path = "../svm-abi/decoder" }
+
+[features]
+default = ["default-memory"]
+default-memory = ["svm-kv/default-memory"]
+default-rocksdb = ["svm-kv/default-rocksdb"]

--- a/crates/svm-runtime/Cargo.toml
+++ b/crates/svm-runtime/Cargo.toml
@@ -6,12 +6,8 @@ license = "MIT"
 edition = "2018"
 publish = false
 
-[target.'cfg(unix)'.dependencies.wasmer]
-version="1.0.0-beta1"
-default-features = false
-features = ["singlepass", "default-jit"]
 
-[target.'cfg(windows)'.dependencies.wasmer]
+[dependencies.wasmer]
 version="1.0.0-beta1"
 default-features = false
 features = ["default-cranelift", "default-jit"]
@@ -24,9 +20,9 @@ wat = "1.0"
 svm-ffi = { path = "../svm-ffi" }
 svm-common = { path = "../svm-common" }
 svm-types = { path = "../svm-types" }
+svm-layout = { path = "../svm-layout" } 
 svm-kv = { path = "../svm-kv", default-features = false }
-svm-layout = { path = "../svm-layout" }
-svm-storage = { path = "../svm-storage" }
+svm-storage = { path = "../svm-storage", default-features = false }
 svm-nibble = { path = "../svm-nibble" }
 svm-codec = { path = "../svm-codec" }
 svm-compiler = { path = "../svm-compiler" }
@@ -40,5 +36,5 @@ svm-abi-decoder = { path = "../svm-abi/decoder" }
 
 [features]
 default = ["default-memory"]
-default-memory = ["svm-kv/default-memory"]
-default-rocksdb = ["svm-kv/default-rocksdb"]
+default-memory = ["svm-kv/default-memory", "svm-storage/default-memory"]
+default-rocksdb = ["svm-kv/default-rocksdb", "svm-storage/default-rocksdb"]

--- a/crates/svm-runtime/src/env/mod.rs
+++ b/crates/svm-runtime/src/env/mod.rs
@@ -1,5 +1,10 @@
 pub mod default;
+
+#[cfg(feature = "default-memory")]
 pub mod memory;
+
+#[cfg(feature = "default-rocksdb")]
 pub mod rocksdb;
+
 pub mod traits;
 pub mod types;

--- a/crates/svm-runtime/src/lib.rs
+++ b/crates/svm-runtime/src/lib.rs
@@ -11,7 +11,10 @@
 
 /// Implements the most high-level API of `SVM`.
 mod runtime;
-pub use runtime::{create_rocksdb_runtime, Config, DefaultRuntime, Runtime, RuntimePtr};
+pub use runtime::{Config, DefaultRuntime, Runtime, RuntimePtr};
+
+#[cfg(feature = "default-rocksdb")]
+pub use runtime::create_rocksdb_runtime;
 
 /// Gas estimation and metering.
 pub mod gas;

--- a/crates/svm-runtime/src/runtime/mod.rs
+++ b/crates/svm-runtime/src/runtime/mod.rs
@@ -1,11 +1,15 @@
 mod config;
 mod default;
 mod ptr;
-mod rocksdb;
 mod runtime;
+
+#[cfg(feature = "default-rocksdb")]
+mod rocksdb;
+
+#[cfg(feature = "default-rocksdb")]
+pub use rocksdb::create_rocksdb_runtime;
 
 pub use config::Config;
 pub use default::DefaultRuntime;
 pub use ptr::RuntimePtr;
-pub use rocksdb::create_rocksdb_runtime;
 pub use runtime::Runtime;

--- a/crates/svm-storage/Cargo.toml
+++ b/crates/svm-storage/Cargo.toml
@@ -12,6 +12,7 @@ publish = false
 
 [dependencies.svm-kv]
 path = "../svm-kv"
+default-features = false
 
 [dependencies.svm-common]
 path = "../svm-common"
@@ -24,3 +25,8 @@ path = "../svm-layout"
 
 [dependencies]
 lazy_static = "1.4.0"
+
+[features]
+default = ["default-memory"]
+default-memory = ["svm-kv/default-memory"]
+default-rocksdb = ["svm-kv/default-rocksdb"]


### PR DESCRIPTION
# Motivation

Compiling `rocksdb` takes a significant amount of time.
We can boost the compilation time by adding features flags that will use for development purposes only 
in-memory key-value store.