### PR TITLE
Calldata encoding to remove nargs

### DIFF
--- a/crates/svm-ffi/src/byte_array.rs
+++ b/crates/svm-ffi/src/byte_array.rs
@@ -122,7 +122,7 @@ impl svm_byte_array {
                     ptr = ptr.add($size);
                 }
             }};
-        };
+        }
 
         for val in values {
             match val {


### PR DESCRIPTION
`Calldata` encoding to remove `nargs`, since it's not really needed and causing some discrepancies in the codec. 

