### PR TITLE
Fix FFI-state-KV allocation

### DIFF
--- a/crates/svm-runtime-c-api/src/api.rs
+++ b/crates/svm-runtime-c-api/src/api.rs
@@ -470,7 +470,7 @@ pub unsafe extern "C" fn svm_ffi_state_kv_create(
         head: None,
     };
 
-    let ffi_kv = Rc::new(RefCell::new(ffi_kv));
+    let ffi_kv: Rc<RefCell<dyn StatefulKV>> = Rc::new(RefCell::new(ffi_kv));
 
     *state_kv = svm_ffi::into_raw(KV_TYPE, ffi_kv);
 


### PR DESCRIPTION
`svm_ffi_state_kv_create` is currently creating the KV as a concrete type (`Rc<RefCell<ExternKV>>`) before allocating it on the heap.
When the pointer is later used in `svm_memory_runtime_create`, the unsafe dereference type inference is to a trait object (`Rc<RefCell<dyn StatefulKV>>`). It makes all methods calls on the dereferenced value to cause segmentation faults. 

This issue was reproduced by the Go client. I don't think it has test coverage in this repo. 
