### PR TITLE
`ExternKV` requires FFI-pointer to `head` as well.

### DIFF
--- a/crates/svm-runtime-c-api/src/api.rs
+++ b/crates/svm-runtime-c-api/src/api.rs
@@ -447,9 +447,19 @@ pub unsafe extern "C" fn svm_memory_state_kv_create(kv: *mut *mut c_void) -> svm
 /// unsafe extern "C" fn set(key_ptr: *const u8, key_len: u32, value_ptr: *const u8, value_len: u32) {}
 /// unsafe extern "C" fn discard() {}
 /// unsafe extern "C" fn checkpoint(state: *mut u8) {}
+/// unsafe extern "C" fn head(state: *mut u8) {}
 ///
 /// let mut kv = std::ptr::null_mut();
-/// let res = unsafe { svm_ffi_state_kv_create(&mut kv, get, set, discard, checkpoint) };
+/// let res = unsafe {
+///   svm_ffi_state_kv_create(
+///     &mut kv,
+///     get,
+///     set,
+///     discard,
+///     checkpoint,
+///     head)
+/// };
+//
 /// assert!(res.is_ok());
 /// ```
 ///
@@ -461,13 +471,14 @@ pub unsafe extern "C" fn svm_ffi_state_kv_create(
     set_fn: unsafe extern "C" fn(*const u8, u32, *const u8, u32),
     discard_fn: unsafe extern "C" fn(),
     checkpoint_fn: unsafe extern "C" fn(*mut u8),
+    head_fn: unsafe extern "C" fn(*mut u8),
 ) -> svm_result_t {
     let ffi_kv = ExternKV {
         get_fn,
         set_fn,
         discard_fn,
         checkpoint_fn,
-        head: None,
+        head_fn,
     };
 
     let ffi_kv: Rc<RefCell<dyn StatefulKV>> = Rc::new(RefCell::new(ffi_kv));

--- a/crates/svm-storage/src/kv/ffi.rs
+++ b/crates/svm-storage/src/kv/ffi.rs
@@ -124,8 +124,6 @@ impl StatefulKV for ExternKV {
     fn rewind(&mut self, _state: &State) {
         // This method isn't supposed to be called (only for tesing purposes)
         // since it's the role of the `Host` to manage to current  `State` of an kenn
-
-        unreachable!()
     }
 
     #[must_use]

--- a/crates/svm-storage/src/kv/ffi.rs
+++ b/crates/svm-storage/src/kv/ffi.rs
@@ -41,6 +41,13 @@ pub type DiscardFn = unsafe extern "C" fn();
 /// have been persisted. It's up to the `Host` to determine when to save data for long-term usage.
 pub type CheckpointFn = unsafe extern "C" fn(*mut u8);
 
+/// # Head
+///
+/// Returns the current `State` of the key-value.
+///
+/// state_ptr - a raw pointer to the where the `head` should be copied to.
+pub type HeadFn = unsafe extern "C" fn(*mut u8);
+
 /// `ExternKV` holds pointers to FFI functions for an external key-value store.
 /// It implements the `StatefulKV` traits by delegation to the FFI functions.
 pub struct ExternKV {
@@ -56,9 +63,8 @@ pub struct ExternKV {
     /// A function-pointer for a key-value store `Checkpoint`
     pub checkpoint_fn: CheckpointFn,
 
-    /// The current `State` (optional).
-    /// used for testing/development/tracing purposes.
-    pub head: Option<State>,
+    /// A function-pointer for a key-value store `Head`
+    pub head_fn: HeadFn,
 }
 
 impl StatefulKV for ExternKV {
@@ -117,13 +123,17 @@ impl StatefulKV for ExternKV {
 
     fn rewind(&mut self, _state: &State) {
         // This method isn't supposed to be called (only for tesing purposes)
-        // since it's the role of the `Host` to manage to current  `State` of an key-value.
+        // since it's the role of the `Host` to manage to current  `State` of an kenn
+
+        unreachable!()
     }
 
     #[must_use]
     fn head(&self) -> State {
-        // This method is supposed to be called only for testing/development/tracing purposes.
+        unsafe {
+            (self.head_fn)(BUF.as_mut_ptr());
 
-        self.head.clone().unwrap()
+            State::from(BUF.as_ptr())
+        }
     }
 }

--- a/crates/svm-storage/src/kv/ffi.rs
+++ b/crates/svm-storage/src/kv/ffi.rs
@@ -122,8 +122,8 @@ impl StatefulKV for ExternKV {
     }
 
     fn rewind(&mut self, _state: &State) {
-        // This method isn't supposed to be called (only for tesing purposes)
-        // since it's the role of the `Host` to manage to current  `State` of an kenn
+        // This method isn't supposed to be called when using the `FFI` key-value store.
+        // since it's the role of the `Host` to manage to do the rewind.
     }
 
     #[must_use]

--- a/crates/svm-storage/src/kv/mock/ffi.rs
+++ b/crates/svm-storage/src/kv/mock/ffi.rs
@@ -10,12 +10,14 @@ use lazy_static::lazy_static;
 
 // This file contains a mock implementation from the `Host`'s angle.
 //
-// The `Host` (i.e `go-spacemesh` but theoretically other Full-Node)
+// The `Host` (i.e `go-spacemesh` but theoretically any other Full-Node)
 // exposes to `ExternKV` (the `FFI_KV` below) the following functions pointers:
+//
 // * `get`
 // * `set`
 // * `discard`
 // * `checkpoint`
+// * `head`
 //
 // Now, the mock implementation of these functions (i.e the `Host`) will be to use `FakeKV`
 // which is an in-memory implementation of the `StatefulKV` trait. (the static `KV` below).
@@ -43,7 +45,7 @@ lazy_static! {
         set_fn: set,
         discard_fn: discard,
         checkpoint_fn: checkpoint,
-        head: None,
+        head_fn: head
     };
 }
 
@@ -91,4 +93,10 @@ pub unsafe extern "C" fn checkpoint(state_ptr: *mut u8) {
     let state = kv!().checkpoint();
 
     std::ptr::copy(state.as_ptr(), state_ptr, State::len());
+}
+
+pub unsafe extern "C" fn head(head_ptr: *mut u8) {
+    let state = kv!().head();
+
+    std::ptr::copy(state.as_ptr(), head_ptr, State::len());
 }


### PR DESCRIPTION
# Motivation

When using FFI key-value store for managing apps' `State` it's up to the host to manage that.
This PR adds a missing piece that demands the host to reply with its most recent `State` (a.k.a the `HEAD`) when asked for.

We could have managed without this method since after we already use `checkpoint` which returns back the new `State`.
However, in order to KISS and be fully compliant with the `StatefulKV` trait - we`d be better having an explicit `head` FFI function as well.

Also, this SMIP has been updated:
https://github.com/spacemeshos/SMIPS/issues/20
