### PR TITLE
Add a Rust toolchain file which defaults to nightly

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "nightly"
+components = ["rustfmt"]
+targets = ["wasm32-unknown-unknown"]
+profile = "minimal"


### PR DESCRIPTION
Recent `rustup` versions (>= 1.23) gained the ability to automatically select Rust toolchain components based on a TOML configuration file. This simplifies IDE interaction, editor and `rust-analyzer` support.