### PR TITLE
Only native host functions

### DIFF
--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -17,7 +17,7 @@ svm-ffi = { path = "../ffi" }
 svm-hash = { path = "../hash" }
 svm-common = { path = "../common" }
 svm-types = { path = "../types" }
-svm-layout = { path = "../layout" } 
+svm-layout = { path = "../layout" }
 svm-kv = { path = "../kv", default-features = false }
 svm-storage = { path = "../storage", default-features = false }
 svm-codec = { path = "../codec" }

--- a/crates/runtime/src/context.rs
+++ b/crates/runtime/src/context.rs
@@ -1,3 +1,5 @@
+//! Implements `Context`. Used for managing data of running `SVM` apps.
+
 use wasmer::Memory;
 
 use std::cell::{Ref, RefCell, RefMut};

--- a/crates/runtime/src/env/memory/app_store.rs
+++ b/crates/runtime/src/env/memory/app_store.rs
@@ -48,7 +48,7 @@ where
         bytes.and_then(|bytes| D::deserialize(&bytes[..]))
     }
 
-    fn find_template_addr(&self, addr: &AppAddr) -> Option<TemplateAddr> {
+    fn resolve_template_addr(&self, addr: &AppAddr) -> Option<TemplateAddr> {
         let app = self.load(addr);
 
         app.map(|x| x.template_addr().clone())

--- a/crates/runtime/src/env/traits/store.rs
+++ b/crates/runtime/src/env/traits/store.rs
@@ -36,5 +36,5 @@ pub trait AppStore {
     fn load(&self, addr: &AppAddr) -> Option<ExtApp>;
 
     #[must_use]
-    fn find_template_addr(&self, addr: &AppAddr) -> Option<TemplateAddr>;
+    fn resolve_template_addr(&self, addr: &AppAddr) -> Option<TemplateAddr>;
 }

--- a/crates/runtime/src/error/mod.rs
+++ b/crates/runtime/src/error/mod.rs
@@ -1,3 +1,4 @@
+///! Crate errors
 mod validate;
 
 pub use validate::ValidateError;

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -20,20 +20,13 @@ pub use runtime::create_rocksdb_runtime;
 mod gas;
 pub use gas::DefaultGasEstimator;
 
-/// Managing the Runtime environment
+mod context;
 mod env;
-pub use env::{Env, EnvTypes};
-
 mod storage;
 
-/// Implements `Context`. Used for managing data of running `SVM` apps.
-mod context;
 pub use context::Context;
+pub use env::{Env, EnvTypes};
 
-/// Implements common functionality to be consumed by tests.
-pub mod testing;
-
-pub mod vmcalls;
-
-/// Crate errors
 pub mod error;
+pub mod testing;
+pub mod vmcalls;

--- a/crates/runtime/src/runtime/config.rs
+++ b/crates/runtime/src/runtime/config.rs
@@ -1,8 +1,16 @@
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 /// Runtime configuration
 #[derive(Debug, Clone)]
 pub struct Config {
     /// The path for the key-value store
-    pub kv_path: PathBuf,
+    kv_path: PathBuf,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            kv_path: PathBuf::new(),
+        }
+    }
 }

--- a/crates/runtime/src/runtime/config.rs
+++ b/crates/runtime/src/runtime/config.rs
@@ -1,16 +1,8 @@
 use std::path::PathBuf;
 
 /// Runtime configuration
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct Config {
     /// The path for the key-value store
     kv_path: PathBuf,
-}
-
-impl Default for Config {
-    fn default() -> Self {
-        Self {
-            kv_path: PathBuf::new(),
-        }
-    }
 }

--- a/crates/runtime/src/runtime/default.rs
+++ b/crates/runtime/src/runtime/default.rs
@@ -520,7 +520,7 @@ where
 
         // Registering the externals provided to the Runtime
         let (name, exports) = &self.imports;
-        debug_assert_ne!(name, "sm");
+        debug_assert_ne!(name, "svm");
 
         import_object.register(name, exports.clone());
 

--- a/crates/runtime/src/runtime/default.rs
+++ b/crates/runtime/src/runtime/default.rs
@@ -520,6 +520,8 @@ where
 
         // Registering the externals provided to the Runtime
         let (name, exports) = &self.imports;
+        debug_assert_ne!(name, "sm");
+
         import_object.register(name, exports.clone());
 
         import_object

--- a/crates/runtime/src/testing.rs
+++ b/crates/runtime/src/testing.rs
@@ -1,3 +1,5 @@
+//! Implements common functionality to be consumed by tests.
+
 use wasmer::{ImportObject, Instance, Memory, MemoryType, Module, Pages, Store};
 
 use std::cell::RefCell;
@@ -110,12 +112,12 @@ pub fn create_memory_runtime(
 
     let template_store = DefaultMemTemplateStore::new();
     let app_store = DefaultMemAppStore::new();
-
     let env = Env::<DefaultMemEnvTypes>::new(app_store, template_store);
 
-    let kv_path = Path::new("");
+    let config = Config::default();
+    let imports = ("sm".to_string(), wasmer::Exports::new());
 
-    DefaultRuntime::new(env, &kv_path, Box::new(storage_builder))
+    DefaultRuntime::new(env, imports, Box::new(storage_builder), config)
 }
 
 /// Returns a function (wrapped inside `Box`) that initializes an App's storage client.

--- a/crates/runtime/src/testing.rs
+++ b/crates/runtime/src/testing.rs
@@ -52,22 +52,6 @@ impl<'a> From<&'a [u8]> for WasmFile<'a> {
     }
 }
 
-/// Creates a new `Wasmer Store`
-pub fn wasmer_store() -> Store {
-    svm_compiler::new_store()
-}
-
-/// Creates a new `Wasmer Memory` consisting of a single page
-/// The memory is of type non-shared and can grow without a limit
-pub fn wasmer_memory(store: &Store) -> Memory {
-    let min = Pages(1);
-    let max = None;
-    let shared = false;
-    let ty = MemoryType::new(min, max, shared);
-
-    Memory::new(store, ty).expect("Memory allocation has failed.")
-}
-
 /// Compiles a wasm program in text format (a.k.a WAST) into a `Module` (`wasmer`)
 pub fn wasmer_compile(store: &Store, wasm_file: WasmFile, gas_limit: Gas) -> Module {
     let wasm = wasm_file.into_bytes();

--- a/crates/runtime/src/vmcalls/mod.rs
+++ b/crates/runtime/src/vmcalls/mod.rs
@@ -1,4 +1,4 @@
-//! Implements the `SVM` vmcalls (a.k.a libcalls / hostcalls / syscalls)
+//! Implements the `SVM` vmcalls (a.k.a `libcalls / hostcalls / syscalls`)
 
 use wasmer::{Exports, Function, Store};
 
@@ -25,8 +25,8 @@ macro_rules! func {
     }};
 }
 
-/// Registers SVM internal host functions (a.k.a vmacalls) into
-/// Into `Wasmer` Import Object (it's done by inserting to input `Exports`)
+/// Registers SVM internal host functions (a.k.a `vmcalls`)
+/// into `Wasmer` Import Object (it's done by inserting to input `Exports`)
 pub fn wasmer_register(store: &Store, ctx: &Context, ns: &mut Exports) {
     ns.insert("svm_static_alloc", func!(store, ctx, static_alloc));
 


### PR DESCRIPTION
The executed SVM-flavored Wasm has imports of `function` kind. 
New kinds of imports (such as `Memory/Table/Global`) are not expected to be used in the foreseeable future.


The functions imports are grouped into: 

### SVM Internals:

These host functions deal primarily with managing the `Account` storage.
The internals are SVM specific and are Node-agnostic.

The internals will be clustered under the `svm` namespace.

### SVM Externals

Here we can inject upon Runtime initialization a  functionality that is Node-aware.
It will include features such as:

* `get_balance` - asking for the current executed Account balance
* `transfer` - sending coins from the current Account to another Account

The externals will be clustered under the `sm` namespace.

This design should make it easier for other Blockchains to integrate with SVM.
The only requirement is that integrating Blockchain Node will provide functions written in Rust.
(and have a type signature abiding to the Wasmer `native host function with env`).


### Notes:

* This PR didn't tackle the `#[ignore]` tests under the `runtime-ffi` crate.
* The externals of SVM will be added incrementally. Most of them will talk directly to the upcoming `Global-State` written in Rust.
* While working on the code I've started using `Account` replacing `App` (see #264) and did some refactoring along the way.

Depends on:
* #269 