### PR TITLE
Replace macros with functions within svm-storage

### DIFF
--- a/crates/storage/tests/account_storage_tests.rs
+++ b/crates/storage/tests/account_storage_tests.rs
@@ -2,22 +2,14 @@ use svm_layout::{FixedLayout, Id};
 use svm_storage::{account::AccountStorage, testing};
 use svm_types::Address;
 
-macro_rules! assert_vars {
-        ($account:expr, $($var_id:expr => $expected:expr), *) => {{
-            $(
-                let actual = $account.read_var(Id($var_id));
-                assert_eq!(actual, $expected);
-             )*
-        }};
-    }
+fn assert_var<const N: usize>(account: &AccountStorage, var_id: u32, expected: [u8; N]) {
+    let var = account.read_var(Id(var_id));
+    assert_eq!(&var[..], &expected[..]);
+}
 
-macro_rules! write_vars {
-        ($account:expr, $($var_id:expr => $value:expr), *) => {{
-            $(
-                $account.write_var(Id($var_id), $value.to_vec());
-             )*
-        }};
-    }
+fn write_var<const N: usize>(account: &mut AccountStorage, var_id: u32, var: [u8; N]) {
+    account.write_var(Id(var_id), var.to_vec());
+}
 
 #[test]
 fn account_storage_vars_are_persisted_only_on_commit() {
@@ -28,29 +20,35 @@ fn account_storage_vars_are_persisted_only_on_commit() {
     let addr = Address::of("@Account");
     let kv = testing::create_account_kv(addr);
 
-    let mut account = AccountStorage::new(layout.clone(), kv.clone());
+    let account = &mut AccountStorage::new(layout.clone(), kv.clone());
 
     // vars are initialized with zeros
-    assert_vars!(account, 0 => [0, 0, 0, 0], 1 => [0, 0]);
-    write_vars!(account, 0 => [10, 20, 30, 40], 1 => [50, 60]);
+    assert_var(account, 0, [0, 0, 0, 0]);
+    assert_var(account, 1, [0, 0]);
+
+    write_var(account, 0, [10, 20, 30, 40]);
+    write_var(account, 1, [50, 60]);
 
     // vars latest version are in memory (uncommitted yet)
-    assert_vars!(account, 0 => [10, 20, 30, 40], 1 => [50, 60]);
+    assert_var(account, 0, [10, 20, 30, 40]);
+    assert_var(account, 1, [50, 60]);
 
     // spin a new account with no in-memory dirty data
-    let account2 = AccountStorage::new(layout.clone(), kv.clone());
+    let account2 = &mut AccountStorage::new(layout.clone(), kv.clone());
 
     // `account`'s' uncommitted changes are not reflected yet
-    assert_vars!(account2, 0 => [0, 0, 0, 0], 1 => [0, 0]);
+    assert_var(account2, 0, [0, 0, 0, 0]);
+    assert_var(account2, 1, [0, 0]);
 
     // now, we'll commit the dirty changes
     let _state = account.commit();
 
     // we'll spin a new account with no caching
-    let account3 = AccountStorage::new(layout.clone(), kv.clone());
+    let account3 = &mut AccountStorage::new(layout.clone(), kv.clone());
 
     // asserting that `commit` persisted the data
-    assert_vars!(account3, 0 => [10, 20, 30, 40], 1 => [50, 60]);
+    assert_var(account3, 0, [10, 20, 30, 40]);
+    assert_var(account3, 1, [50, 60]);
 }
 
 #[test]


### PR DESCRIPTION
As per title. Closes https://github.com/spacemeshos/svm/issues/291.

Which one do you @YaronWittenstein prefer? With macros or functions? It seems more readable to me, but it's such a small change that reverting it back is perfectly fine for me.