### PR TITLE
svm-runtime: Injecting the `Envelope` and `Context` into `FuncEnv`

### DIFF
--- a/crates/codec/src/section/preview.rs
+++ b/crates/codec/src/section/preview.rs
@@ -23,7 +23,7 @@ impl SectionPreview {
         self.kind
     }
 
-    /// Returns the referred [`Section`]'s binary byte size.
+    /// Returns the referred [`Section`](svm_types::Section)'s binary byte size.
     pub fn byte_size(&self) -> u32 {
         self.byte_size
     }

--- a/crates/runtime/src/runtime/call.rs
+++ b/crates/runtime/src/runtime/call.rs
@@ -1,4 +1,4 @@
-use svm_types::{Address, Gas, State, TemplateAddr};
+use svm_types::{Address, Context, Envelope, Gas, State, TemplateAddr};
 
 /// Information regarding a Wasm function call.
 #[doc(hidden)]
@@ -12,4 +12,6 @@ pub struct Call<'a> {
     pub gas_used: Gas,
     pub gas_left: Gas,
     pub within_spawn: bool,
+    pub context: &'a Context,
+    pub envelope: &'a Envelope,
 }

--- a/crates/runtime/src/runtime/failure.rs
+++ b/crates/runtime/src/runtime/failure.rs
@@ -3,7 +3,6 @@ use svm_types::{ReceiptLog, RuntimeError};
 #[derive(Debug, PartialEq, Clone)]
 pub struct Failure {
     err: RuntimeError,
-
     logs: Vec<ReceiptLog>,
 }
 

--- a/crates/runtime/src/runtime/mod.rs
+++ b/crates/runtime/src/runtime/mod.rs
@@ -48,7 +48,7 @@ pub trait Runtime {
     /// Spawns a new `Account`
     fn spawn(&mut self, envelope: &Envelope, message: &[u8], context: &Context) -> SpawnReceipt;
 
-    /// Verifies a [`Transaction`] before execution.
+    /// Verifies a [`Transaction`](svm_types::Transaction) before execution.
     fn verify(
         &self,
         envelope: &Envelope,
@@ -56,7 +56,7 @@ pub trait Runtime {
         context: &Context,
     ) -> Result<bool, RuntimeError>;
 
-    /// Executes a [`Transaction`] and returns its output [`CallReceipt`].
+    /// Executes a [`Transaction`](svm_types::Transaction) and returns its output [`CallReceipt`].
     ///
     /// This function should be called only if the `verify` stage has passed.
     fn call(&mut self, envelope: &Envelope, message: &[u8], context: &Context) -> CallReceipt;

--- a/crates/runtime/src/vmcalls/alloc.rs
+++ b/crates/runtime/src/vmcalls/alloc.rs
@@ -70,7 +70,7 @@ fn grow_memory(env: &FuncEnv, bytes: u32) {
     }
 
     let env_ref = env.borrow();
-    let memory = env_ref.get_memory();
+    let memory = env_ref.memory();
 
     memory.grow(pages).unwrap();
 }
@@ -80,5 +80,5 @@ fn set_used_memory(env: &FuncEnv, used: u64) {
 }
 
 fn allocated_pages(env: &FuncEnv) -> u32 {
-    env.borrow().get_memory().size().0
+    env.borrow().memory().size().0
 }

--- a/crates/runtime/src/vmcalls/calldata.rs
+++ b/crates/runtime/src/vmcalls/calldata.rs
@@ -12,5 +12,5 @@ pub fn calldata_len(env: &FuncEnv) -> i32 {
 
 #[inline]
 fn calldata(env: &FuncEnv) -> (usize, usize) {
-    env.borrow().get_calldata()
+    env.borrow().calldata()
 }

--- a/crates/runtime/src/vmcalls/logs.rs
+++ b/crates/runtime/src/vmcalls/logs.rs
@@ -12,7 +12,7 @@ pub fn log(env: &FuncEnv, msg_ptr: u32, msg_len: u32, code: u32) {
 
     let msg: Vec<u8> = {
         let borrow = env.borrow();
-        let memory = borrow.get_memory();
+        let memory = borrow.memory();
 
         memory.view()[start..end]
             .iter()

--- a/crates/runtime/src/vmcalls/storage.rs
+++ b/crates/runtime/src/vmcalls/storage.rs
@@ -10,7 +10,7 @@ macro_rules! store_n_impl {
 
         let bytes: Vec<u8> = {
             let borrow = $env.borrow();
-            let memory = borrow.get_memory();
+            let memory = borrow.memory();
             let start = $mem_ptr as usize;
             let end = start + $nbytes;
             let view = &memory.view::<u8>()[start..end];
@@ -35,7 +35,7 @@ macro_rules! load_n_impl {
         assert_eq!(nbytes, $nbytes);
 
         let borrow = $env.borrow();
-        let memory = borrow.get_memory();
+        let memory = borrow.memory();
         let start = $mem_ptr as usize;
         let end = start + $nbytes;
         let view = &memory.view::<u8>()[start..end];

--- a/crates/runtime/tests/vmcalls_tests.rs
+++ b/crates/runtime/tests/vmcalls_tests.rs
@@ -3,7 +3,7 @@ use wasmer::{imports, NativeFunc};
 use svm_layout::{FixedLayout, Id};
 use svm_runtime::testing::{self, WasmFile};
 use svm_runtime::{vmcalls, FuncEnv};
-use svm_types::{Address, ReceiptLog, TemplateAddr};
+use svm_types::{Address, Context, Envelope, ReceiptLog, TemplateAddr};
 
 /// Creates a new `Wasmer Store`
 pub fn wasmer_store() -> wasmer::Store {
@@ -120,13 +120,14 @@ fn vmcalls_get32_set32() {
 
     let store = wasmer_store();
     let storage = testing::blank_storage(&account_addr, &layout);
-
-    let env = FuncEnv::new(storage, &template_addr, &account_addr);
+    let envelope = Envelope::default();
+    let context = Context::default();
+    let func_env = FuncEnv::new(storage, &envelope, &context, &template_addr, &account_addr);
 
     let import_object = imports! {
         "svm" => {
-            "svm_get32" => func!(store, env, vmcalls::get32),
-            "svm_set32" => func!(store, env, vmcalls::set32),
+            "svm_get32" => func!(store, func_env, vmcalls::get32),
+            "svm_set32" => func!(store, func_env, vmcalls::set32),
         }
     };
 
@@ -143,7 +144,7 @@ fn vmcalls_get32_set32() {
 
     assert_vars32!(instance, 0 => 5, 1 => 10);
 
-    assert_storage!(env, 0 => [5, 0, 0, 0], 1 => [10, 0]);
+    assert_storage!(func_env, 0 => [5, 0, 0, 0], 1 => [10, 0]);
 }
 
 #[test]
@@ -154,12 +155,14 @@ fn vmcalls_get64_set64() {
 
     let store = wasmer_store();
     let storage = testing::blank_storage(&account_addr, &layout);
-    let env = FuncEnv::new(storage, &template_addr, &account_addr);
+    let envelope = Envelope::default();
+    let context = Context::default();
+    let func_env = FuncEnv::new(storage, &envelope, &context, &template_addr, &account_addr);
 
     let import_object = imports! {
         "svm" => {
-            "svm_get64" => func!(store, env, vmcalls::get64),
-            "svm_set64" => func!(store, env, vmcalls::set64),
+            "svm_get64" => func!(store, func_env, vmcalls::get64),
+            "svm_set64" => func!(store, func_env, vmcalls::set64),
         },
     };
 
@@ -176,7 +179,7 @@ fn vmcalls_get64_set64() {
 
     assert_vars64!(instance, 0 => 5, 1 => 10);
 
-    assert_storage!(env, 0 => [5, 0, 0, 0], 1 => [10, 0]);
+    assert_storage!(func_env, 0 => [5, 0, 0, 0], 1 => [10, 0]);
 }
 
 #[test]
@@ -188,13 +191,22 @@ fn vmcalls_load160() {
     let store = wasmer_store();
     let memory = wasmer_memory(&store);
     let storage = testing::blank_storage(&account_addr, &layout);
-    let env = FuncEnv::new_with_memory(memory.clone(), storage, &template_addr, &account_addr);
+    let envelope = Envelope::default();
+    let context = Context::default();
+    let func_env = FuncEnv::new_with_memory(
+        memory.clone(),
+        storage,
+        &envelope,
+        &context,
+        &template_addr,
+        &account_addr,
+    );
 
     let import_object = imports! {
         "svm" => {
             "memory" => memory.clone(),
-            "svm_load160" => func!(store, env, vmcalls::load160),
-            "svm_store160" => func!(store, env, vmcalls::store160),
+            "svm_load160" => func!(store, func_env, vmcalls::load160),
+            "svm_store160" => func!(store, func_env, vmcalls::store160),
         },
     };
 
@@ -205,7 +217,7 @@ fn vmcalls_load160() {
     );
 
     {
-        let storage = &mut env.borrow_mut().storage;
+        let storage = &mut func_env.borrow_mut().storage;
         storage.write_var(Id(0), account_addr.as_slice().to_vec());
     }
 
@@ -230,13 +242,22 @@ fn vmcalls_store160() {
     let store = wasmer_store();
     let memory = wasmer_memory(&store);
     let storage = testing::blank_storage(&account_addr, &layout);
-    let env = FuncEnv::new_with_memory(memory.clone(), storage, &template_addr, &account_addr);
+    let envelope = Envelope::default();
+    let context = Context::default();
+    let func_env = FuncEnv::new_with_memory(
+        memory.clone(),
+        storage,
+        &envelope,
+        &context,
+        &template_addr,
+        &account_addr,
+    );
 
     let import_object = imports! {
         "svm" => {
             "memory" => memory.clone(),
-            "svm_load160" => func!(store, env, vmcalls::load160),
-            "svm_store160" => func!(store, env, vmcalls::store160),
+            "svm_load160" => func!(store, func_env, vmcalls::load160),
+            "svm_store160" => func!(store, func_env, vmcalls::store160),
         },
     };
 
@@ -256,7 +277,7 @@ fn vmcalls_store160() {
 
     func.call(var_id, ptr).expect("function has failed");
 
-    assert_storage!(env, 0 => account_addr.as_slice());
+    assert_storage!(func_env, 0 => account_addr.as_slice());
 }
 
 #[test]
@@ -268,12 +289,21 @@ fn vmcalls_log() {
     let store = wasmer_store();
     let memory = wasmer_memory(&store);
     let storage = testing::blank_storage(&account_addr, &layout);
-    let env = FuncEnv::new_with_memory(memory.clone(), storage, &template_addr, &account_addr);
+    let envelope = Envelope::default();
+    let context = Context::default();
+    let func_env = FuncEnv::new_with_memory(
+        memory.clone(),
+        storage,
+        &envelope,
+        &context,
+        &template_addr,
+        &account_addr,
+    );
 
     let import_object = imports! {
         "svm" => {
             "memory" => memory.clone(),
-            "svm_log" => func!(store, env, vmcalls::log),
+            "svm_log" => func!(store, func_env, vmcalls::log),
         },
     };
 
@@ -285,13 +315,13 @@ fn vmcalls_log() {
         cell.set(*byte);
     }
 
-    let logs = env.borrow_mut().take_logs();
+    let logs = func_env.borrow_mut().take_logs();
     assert!(logs.is_empty());
 
     let func = instance.exports.get_function("sayHello").unwrap();
     let _ = func.call(&[]).unwrap();
 
-    let logs = env.borrow_mut().take_logs();
+    let logs = func_env.borrow_mut().take_logs();
 
     assert_eq!(
         logs,

--- a/crates/types/src/transaction/context.rs
+++ b/crates/types/src/transaction/context.rs
@@ -9,7 +9,7 @@ use crate::{Layer, State, TransactionId};
 ///
 /// The [`Context`]'s data should be passed externally from the `Node`.
 /// That's why we are not allowed to touch its content, and have it immutable.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Context {
     tx_id: TransactionId,
     layer: Layer,

--- a/crates/types/src/transaction/envelope.rs
+++ b/crates/types/src/transaction/envelope.rs
@@ -6,6 +6,7 @@ use crate::{Address, Gas};
 ///
 /// The [`Envelope`]'s data should be passed externally from the `Node`.
 /// That's why we are not allowed to touch its content, and have it immutable.
+#[derive(Debug, Clone, PartialEq)]
 pub struct Envelope {
     principal: Address,
     amount: u64,


### PR DESCRIPTION
This PR implements injection of both the `Envelope` and `Context` into the `FuncEnv`.
This is a preparation work for adding future host functions that will expose more information.

As an example, an executed transaction can ask for it's `Id` (the `transaction id` sits under the `Context`).