### PR TITLE
Replace `Runtime` locking mechanisms with thread-safe alternatives

### DIFF
--- a/crates/storage/src/testing.rs
+++ b/crates/storage/src/testing.rs
@@ -1,7 +1,6 @@
 //! Tests helpers
 
-use std::cell::RefCell;
-use std::rc::Rc;
+use std::sync::{Arc, Mutex};
 
 use svm_types::Address;
 
@@ -9,8 +8,8 @@ use crate::account::AccountKVStore;
 use crate::kv::{FakeKV, StatefulKV};
 
 /// Creates an in-memory stateful key-value store and returns it wrapped within `Rc<RefCell<..>>`
-pub fn create_kv() -> Rc<RefCell<dyn StatefulKV>> {
-    Rc::new(RefCell::new(FakeKV::new()))
+pub fn create_kv() -> Arc<Mutex<dyn StatefulKV + Send>> {
+    Arc::new(Mutex::new(FakeKV::new()))
 }
 
 /// Creates an [`AccountKVStore`] for an `Account` having `Address` equals `account_addr`.


### PR DESCRIPTION
Before this PR, `FuncEnv` implemented `Sync` and `Send` in an unsafe and potentially UB-prone manner. While SVM indeed is single-threaded, we can't guarantee that `wasmer` will not pass around items between threads (which they might even do unwittingly via `async` / `await`). We can't guarantee that `wasmer` is single-threaded as well, and we shouldn't, given that `WasmerEnv` requires `Sync + Send`.

This PR replaces some `Rc<RefCell<...>>` patterns with `Arc<Mutex<...>>` and `Arc<RwLock<...>>`. See https://github.com/spacemeshos/svm/issues/260.