### PR TITLE
Adopt `thiserror` for `ParseError` and `#[derive(Debug)]`

### DIFF
--- a/crates/codec/src/error.rs
+++ b/crates/codec/src/error.rs
@@ -1,49 +1,34 @@
 use thiserror::Error;
 
-use std::fmt;
-
 use crate::Field;
 
 #[allow(missing_docs)]
-#[derive(PartialEq, Clone, Error)]
+#[derive(Debug, Clone, PartialEq, Error)]
 pub enum ParseError {
+    #[error("Reached EOF")]
     ReachedEOF,
+
+    #[error("Expected EOF but there are more left bytes")]
     ExpectedEOF,
+
+    #[error("Field `{0}` must not be empty")]
     EmptyField(Field),
+
+    #[error("Not enough bytes for field `{0}`")]
     NotEnoughBytes(Field),
+
+    #[error("Too enough bytes for field `{0}`")]
     TooManyBytes(Field),
+
+    #[error("Field `{0}` is not supported yet")]
     NotSupported(Field),
+
+    #[error("Field `{0}` must be a valid UTF-8 string")]
     InvalidUTF8String(Field),
+
+    #[error("Unexpected Wasm value layout for field `{0}`")]
     UnexpectedLayout(Field),
+
+    #[error("Invalid section kind")]
     InvalidSection,
-}
-
-impl fmt::Display for ParseError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            ParseError::ReachedEOF => write!(f, "Reached EOF"),
-            ParseError::ExpectedEOF => write!(f, "Expected EOF but there are more left bytes"),
-            ParseError::EmptyField(field) => write!(f, "Field `{}` must not be empty", field),
-            ParseError::NotEnoughBytes(field) => {
-                write!(f, "Not enough bytes for field `{}`", field)
-            }
-            ParseError::TooManyBytes(field) => write!(f, "Too many bytes for field `{}`", field),
-            ParseError::NotSupported(field) => {
-                write!(f, "Feature `{}` is not supported yet", field)
-            }
-            ParseError::InvalidUTF8String(field) => {
-                write!(f, "Field `{}` must be a valid UTF-8 string", field)
-            }
-            ParseError::UnexpectedLayout(field) => {
-                write!(f, "Unexpected Wasm value layout for field `{}`", field)
-            }
-            ParseError::InvalidSection => write!(f, "Invalid section kind"),
-        }
-    }
-}
-
-impl fmt::Debug for ParseError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        <Self as fmt::Display>::fmt(self, f)
-    }
 }


### PR DESCRIPTION
This simplifies [`Display`](https://doc.rust-lang.org/std/fmt/trait.Display.html) logic for `svm_codec::ParseError` via `thiserror` and derives the implementation of `Debug`.