### PR TITLE
Always compile WASM APIs in `svm_codec`

### DIFF
--- a/crates/codec/src/lib.rs
+++ b/crates/codec/src/lib.rs
@@ -35,6 +35,8 @@ pub mod receipt;
 mod error;
 pub use error::ParseError;
 
+use api::json::JsonError;
+
 /// # WASM API
 ///
 /// The following API methods are annotated with `#[cfg(target_arch = "wasm32")]`.
@@ -48,7 +50,7 @@ pub use error::ParseError;
 ///
 /// The CI of the `SVM` also runs the js tests and outputs `svm_codec.wasm` under the artifacts.
 ///
-
+///
 /// ## WASM API Usage
 ///
 /// Before calling `wasm_deploy / wasm_spawn / wasm_call` we need first to allocate
@@ -77,20 +79,6 @@ pub use error::ParseError;
 /// ```
 ///
 
-#[cfg(target_arch = "wasm32")]
-macro_rules! wasm_func_call {
-    ($func:ident, $buf_offset:expr) => {{
-        match api::wasm::$func($buf_offset as usize) {
-            Ok(tx_offset) => tx_offset as _,
-            Err(err) => {
-                let err_offset = api::wasm::into_error_buffer(err);
-
-                err_offset as _
-            }
-        }
-    }};
-}
-
 /// ## WASM `Deploy Template`
 ///
 /// Reads the WASM buffer given at parameter `offset` containing a JSON value.
@@ -99,9 +87,8 @@ macro_rules! wasm_func_call {
 /// Returns a pointer to a new WASM buffer holding the encoded transaction.
 /// If the encoding failed, the returned WASM buffer will contain a String containing the error message.
 #[no_mangle]
-#[cfg(target_arch = "wasm32")]
 pub extern "C" fn wasm_encode_deploy(offset: i32) -> i32 {
-    wasm_func_call!(encode_deploy, offset)
+    wasm_func_call(api::wasm::encode_deploy, offset)
 }
 
 /// ## WASM `Spawn Account`
@@ -112,9 +99,8 @@ pub extern "C" fn wasm_encode_deploy(offset: i32) -> i32 {
 /// Returns a pointer to a new WASM buffer holding the encoded transaction.
 /// If the encoding fails, the returned WASM buffer will contain a String containing the error message.
 #[no_mangle]
-#[cfg(target_arch = "wasm32")]
 pub extern "C" fn wasm_encode_spawn(offset: i32) -> i32 {
-    wasm_func_call!(encode_spawn, offset)
+    wasm_func_call(api::wasm::encode_spawn, offset)
 }
 
 /// Decodes the encoded `Spawn Account` given as a WASM buffer (parameter `offset`).
@@ -122,9 +108,8 @@ pub extern "C" fn wasm_encode_spawn(offset: i32) -> i32 {
 /// Returns a pointer to a new WASM buffer holding the decoded transaction.
 /// If the decoding fails, the returned WASM buffer will contain a String containing the error message.
 #[no_mangle]
-#[cfg(target_arch = "wasm32")]
 pub extern "C" fn wasm_decode_spawn(offset: i32) -> i32 {
-    wasm_func_call!(decode_spawn, offset)
+    wasm_func_call(api::wasm::decode_spawn, offset)
 }
 
 /// ## WASM `Call Account`
@@ -135,9 +120,8 @@ pub extern "C" fn wasm_decode_spawn(offset: i32) -> i32 {
 /// Returns a pointer to a new WASM buffer holding the encoded transaction.
 /// If the encoding failed, the returned WASM buffer will contain a String containing the error message.
 #[no_mangle]
-#[cfg(target_arch = "wasm32")]
 pub extern "C" fn wasm_encode_call(offset: i32) -> i32 {
-    wasm_func_call!(encode_call, offset)
+    wasm_func_call(api::wasm::encode_call, offset)
 }
 
 /// Decodes the encoded `Call Account` given as a WASM buffer (parameter `offset`).
@@ -145,9 +129,8 @@ pub extern "C" fn wasm_encode_call(offset: i32) -> i32 {
 /// Returns a pointer to a new WASM buffer holding the decoded transaction.
 /// If the decoding fails, the returned WASM buffer will contain a String containing the error message.
 #[no_mangle]
-#[cfg(target_arch = "wasm32")]
 pub extern "C" fn wasm_decode_call(offset: i32) -> i32 {
-    wasm_func_call!(decode_call, offset)
+    wasm_func_call(api::wasm::decode_call, offset)
 }
 
 /// ## WASM Buffer Allocation
@@ -156,7 +139,6 @@ pub extern "C" fn wasm_decode_call(offset: i32) -> i32 {
 ///
 /// For more info read: `api::wasm::alloc`
 #[no_mangle]
-#[cfg(target_arch = "wasm32")]
 pub extern "C" fn wasm_alloc(length: i32) -> i32 {
     let offset = api::wasm::alloc(length as usize);
 
@@ -169,7 +151,6 @@ pub extern "C" fn wasm_alloc(length: i32) -> i32 {
 ///
 /// For more info read: `api::wasm::free`
 #[no_mangle]
-#[cfg(target_arch = "wasm32")]
 pub extern "C" fn wasm_free(offset: i32) {
     api::wasm::free(offset as usize);
 }
@@ -178,7 +159,6 @@ pub extern "C" fn wasm_free(offset: i32) {
 ///
 /// Returns the buffer `Data` byte-length
 #[no_mangle]
-#[cfg(target_arch = "wasm32")]
 pub extern "C" fn wasm_buffer_length(offset: i32) -> i32 {
     let buf_len = api::wasm::wasm_buf_len(offset as usize);
 
@@ -189,7 +169,6 @@ pub extern "C" fn wasm_buffer_length(offset: i32) -> i32 {
 ///
 /// Returns a pointer to the buffer `Data`
 #[no_mangle]
-#[cfg(target_arch = "wasm32")]
 pub extern "C" fn wasm_buffer_data(offset: i32) -> i32 {
     let (data_offset, _len) = api::wasm::wasm_buf_data_offset(offset as usize);
 
@@ -202,9 +181,8 @@ pub extern "C" fn wasm_buffer_data(offset: i32) -> i32 {
 /// Encodes the `Input Data`, and returns a pointer to a new WASM buffer holding the encoded `Input Data`.
 /// If the encoding fails, the returned WASM buffer will contain a String containing the error message.
 #[no_mangle]
-#[cfg(target_arch = "wasm32")]
 pub extern "C" fn wasm_encode_inputdata(offset: i32) -> i32 {
-    wasm_func_call!(encode_inputdata, offset)
+    wasm_func_call(api::wasm::encode_inputdata, offset)
 }
 
 /// Decodes the encoded `Input Data` given as a WASM buffer (parameter `offset`).
@@ -212,9 +190,8 @@ pub extern "C" fn wasm_encode_inputdata(offset: i32) -> i32 {
 /// Returns a pointer to a new WASM buffer holding the decoded `Input Data`.
 /// If the decoding fails, the returned WASM buffer will contain a String containing the error message.
 #[no_mangle]
-#[cfg(target_arch = "wasm32")]
 pub extern "C" fn wasm_decode_inputdata(offset: i32) -> i32 {
-    wasm_func_call!(decode_inputdata, offset)
+    wasm_func_call(api::wasm::decode_inputdata, offset)
 }
 
 /// Decodes the encoded `Receipt` given as a WASM buffer (parameter `offset`).
@@ -222,7 +199,20 @@ pub extern "C" fn wasm_decode_inputdata(offset: i32) -> i32 {
 /// Returns a pointer to a new WASM buffer holding the decoded `Receipt`.
 /// If the decoding fails, the returned WASM buffer will contain a String containing the error message.
 #[no_mangle]
-#[cfg(target_arch = "wasm32")]
 pub extern "C" fn wasm_decode_receipt(offset: i32) -> i32 {
-    wasm_func_call!(decode_receipt, offset)
+    wasm_func_call(api::wasm::decode_receipt, offset)
+}
+
+fn wasm_func_call<F>(f: F, offset: i32) -> i32
+where
+    F: Fn(usize) -> Result<usize, JsonError>,
+{
+    match f(offset as usize) {
+        Ok(tx_offset) => tx_offset as i32,
+        Err(err) => {
+            let err_offset = api::wasm::into_error_buffer(err);
+
+            err_offset as _
+        }
+    }
 }


### PR DESCRIPTION
At the moment, we only compile WASM FFI functions when compiling to `wasm32-unknown-unknown`. This distinction between compilation targets, however, is not necessary and diminishes the amount of compiler help that we get when compiling to other targets. Let's make sure that those APIs are always present in the code and reduce target fragmentation.