### PR TITLE
Safer C APIs

### DIFF
--- a/crates/runtime-ffi/src/byte_array.rs
+++ b/crates/runtime-ffi/src/byte_array.rs
@@ -79,7 +79,7 @@ impl svm_byte_array {
         unsafe { std::slice::from_raw_parts_mut(self.bytes as _, self.length as usize) }
     }
 
-    /// Copies `self` into a new [`Vec`](std::vec::Vec).
+    /// Copies `self` into a new [`Vec`].
     pub fn to_vec(&self) -> Vec<u8> {
         self.as_slice().to_vec()
     }
@@ -105,19 +105,18 @@ impl svm_byte_array {
     }
 }
 
-// ///
-// /// # Examples
-// ///
-// /// ```rust
-// /// use svm_runtime_ffi::svm_byte_array;
-// ///
-// /// let array = svm_byte_array::default();
-// ///
-// /// assert_eq!(std::ptr::null(), array.bytes);
-// /// assert_eq!(0, array.length);
-// /// assert_eq!(0, array.capacity);
-// /// ```
-// ///
+///
+/// # Examples
+///
+/// ```rust
+/// use svm_runtime_ffi::svm_byte_array;
+///
+/// let array = svm_byte_array::default();
+///
+/// assert_eq!(array.len(), 0);
+/// assert_eq!(array.capacity(), 0);
+/// ```
+///
 impl Default for svm_byte_array {
     fn default() -> Self {
         Self {

--- a/crates/runtime-ffi/src/lib.rs
+++ b/crates/runtime-ffi/src/lib.rs
@@ -7,6 +7,7 @@
 #![deny(dead_code)]
 #![deny(unreachable_code)]
 #![feature(vec_into_raw_parts)]
+#![feature(ptr_as_uninit)]
 
 mod address;
 mod byte_array;
@@ -89,18 +90,5 @@ pub fn into_raw<T: 'static>(ty: Type, obj: T) -> *mut c_void {
 #[inline]
 pub(crate) unsafe fn from_raw<T: 'static>(ty: Type, ptr: *mut T) -> T {
     tracking::decrement_live(ty);
-
     *Box::from_raw(ptr)
-}
-
-/// Receives a `*const c_void` pointer and returns the a mutable borrowed reference to the underlying object.
-///
-/// # Safety
-///
-/// * If raw pointer doesn't point to a struct of type T it's an U.B
-/// * In case the referenced struct is already borrowed it's an U.B
-#[must_use]
-#[inline]
-pub(crate) unsafe fn as_mut<'a, T>(ptr: *mut c_void) -> &'a mut T {
-    &mut *(ptr as *mut T)
 }

--- a/crates/runtime-ffi/src/ref.rs
+++ b/crates/runtime-ffi/src/ref.rs
@@ -32,12 +32,6 @@ impl RuntimeRef {
 
         crate::from_raw(RUNTIME_REF_TYPE, ptr)
     }
-
-    pub unsafe fn as_native<'a>(ptr: *mut c_void) -> &'a mut Box<dyn Runtime> {
-        let runtime: &mut RuntimeRef = crate::as_mut(ptr);
-
-        &mut *runtime
-    }
 }
 
 impl Deref for RuntimeRef {

--- a/crates/runtime-ffi/tests/api_tests.rs
+++ b/crates/runtime-ffi/tests/api_tests.rs
@@ -81,30 +81,30 @@ fn encode_context(ctx: &Context) -> svm_byte_array {
 
 unsafe fn destroy(byte_arrays: &[svm_byte_array]) {
     for byte_array in byte_arrays {
-        let _ = api::svm_byte_array_destroy(byte_array.clone());
+        let _ = api::svm_byte_array_destroy(*byte_array);
     }
 }
 
 #[test]
 fn svm_resources_tracking() {
+    tracking::set_tracking_on();
+
+    let ty1 = Type::Str("#1");
+    let s1 = "Hello".to_string();
+    let hello: svm_byte_array = (ty1, s1).into();
+
+    let ty2 = Type::Str("#2");
+    let s2 = "World".to_string();
+    let world: svm_byte_array = (ty2, s2).into();
+
+    let s3 = "New World".to_string();
+    let new_world: svm_byte_array = (ty2, s3).into();
+
+    assert_eq!(api::svm_total_live_resources(), 3);
+
+    let iter = api::svm_resource_iter_new();
+
     unsafe {
-        tracking::set_tracking_on();
-
-        let ty1 = Type::Str("#1");
-        let s1 = "Hello".to_string();
-        let hello: svm_byte_array = (ty1, s1).into();
-
-        let ty2 = Type::Str("#2");
-        let s2 = "World".to_string();
-        let world: svm_byte_array = (ty2, s2).into();
-
-        let s3 = "New World".to_string();
-        let new_world: svm_byte_array = (ty2, s3).into();
-
-        assert_eq!(api::svm_total_live_resources(), 3);
-
-        let iter = api::svm_resource_iter_new();
-
         let r1 = &mut *api::svm_resource_iter_next(iter);
         let r2 = &mut *api::svm_resource_iter_next(iter);
 


### PR DESCRIPTION
See #260.

- Use `#![deny(unsafe_op_in_unsafe_fn)]`, which makes auditing `unsafe` code much easier.
- Use method-based casting on raw pointers rather than `as`. Behavior is better documented and they protect against `NULL` deference.
- Try to push `unsafe` code as high as possible within function bodies to highlight what `unsafe` operations we do.
- Cast pointers to reference as early as possible as they are the main cause of `unsafe`.