### PR TITLE
Disallow broken intra-doc Cargo links

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,12 @@ jobs:
           toolchain: nightly
           command: test
           args: --all --features=default-cranelift,default-memory --no-default-features -- --nocapture
+          components: rustdoc
+      - name: Run `cargo doc`
+        uses: actions-rs/cargo@v1
+        with:
+          command: doc
+          args: --all
   wasm_codec:
     runs-on: macos-latest
     strategy:

--- a/crates/abi/decoder/src/lib.rs
+++ b/crates/abi/decoder/src/lib.rs
@@ -15,6 +15,7 @@
 #![allow(unused)]
 #![deny(dead_code)]
 #![deny(unreachable_code)]
+#![deny(rustdoc::broken_intra_doc_links)]
 
 mod calldata;
 mod cursor;

--- a/crates/abi/encoder/src/lib.rs
+++ b/crates/abi/encoder/src/lib.rs
@@ -6,6 +6,7 @@
 #![deny(unused)]
 #![deny(dead_code)]
 #![deny(unreachable_code)]
+#![deny(rustdoc::broken_intra_doc_links)]
 
 mod traits;
 mod types;

--- a/crates/abi/layout/src/lib.rs
+++ b/crates/abi/layout/src/lib.rs
@@ -75,6 +75,7 @@
 #![deny(unused)]
 #![deny(dead_code)]
 #![deny(unreachable_code)]
+#![deny(rustdoc::broken_intra_doc_links)]
 
 #[allow(clippy::unusual_byte_groupings)]
 #[doc(hidden)]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -3,6 +3,7 @@
 //! ABI.
 
 #![allow(unused)]
+#![deny(rustdoc::broken_intra_doc_links)]
 
 mod subcmd_craft_deploy;
 mod subcmd_tx;

--- a/crates/codec/src/lib.rs
+++ b/crates/codec/src/lib.rs
@@ -10,6 +10,7 @@
 #![deny(unused)]
 #![deny(dead_code)]
 #![allow(unreachable_code)]
+#![deny(rustdoc::broken_intra_doc_links)]
 #![feature(vec_into_raw_parts)]
 
 mod codec_impls;

--- a/crates/gas/src/lib.rs
+++ b/crates/gas/src/lib.rs
@@ -1,9 +1,10 @@
+//! This crate is responsible for doing gas validation & estimation for transactions.
+
 #![allow(missing_docs)]
 #![allow(unused)]
 #![allow(dead_code)]
 #![allow(unreachable_code)]
-
-//! This crate is responsible for doing gas validation & estimation for transactions.
+#![deny(rustdoc::broken_intra_doc_links)]
 
 mod call_graph;
 mod cfg;

--- a/crates/hash/src/lib.rs
+++ b/crates/hash/src/lib.rs
@@ -1,10 +1,11 @@
-//! A [`Hasher`] trait for wide-digest algorithms and its [`DefaultHasher`]
+//! A [`Hasher`] trait for wide-digest algorithms and [`Blake3Hasher`]
 //! implementation.
 
 #![deny(missing_docs)]
 #![deny(unused)]
 #![deny(dead_code)]
 #![deny(unreachable_code)]
+#![deny(rustdoc::broken_intra_doc_links)]
 
 /// A low-level trait for defining a hasher.
 pub trait Hasher: Default {

--- a/crates/kv/src/lib.rs
+++ b/crates/kv/src/lib.rs
@@ -2,6 +2,7 @@
 #![deny(unused)]
 #![deny(dead_code)]
 #![deny(unreachable_code)]
+#![deny(rustdoc::broken_intra_doc_links)]
 
 //! The `svm-kv` crate is responsible on providing different implementations for the `KVStore` trait.
 

--- a/crates/layout/src/lib.rs
+++ b/crates/layout/src/lib.rs
@@ -2,6 +2,7 @@
 #![allow(unused)]
 #![allow(dead_code)]
 #![allow(unreachable_code)]
+#![deny(rustdoc::broken_intra_doc_links)]
 
 //! This crate is responsible of representing an `Account`'s storage variables `Layout`.
 

--- a/crates/program/src/lib.rs
+++ b/crates/program/src/lib.rs
@@ -6,6 +6,7 @@
 #![deny(unused)]
 #![deny(dead_code)]
 #![deny(unreachable_code)]
+#![deny(rustdoc::broken_intra_doc_links)]
 
 use parity_wasm::elements::Instruction;
 

--- a/crates/query/src/lib.rs
+++ b/crates/query/src/lib.rs
@@ -7,6 +7,7 @@
 #![deny(unused)]
 #![deny(dead_code)]
 #![deny(unreachable_code)]
+#![deny(rustdoc::broken_intra_doc_links)]
 
 pub mod query;
 pub mod render;

--- a/crates/runtime-ffi/src/api.rs
+++ b/crates/runtime-ffi/src/api.rs
@@ -148,7 +148,8 @@ pub unsafe extern "C" fn svm_runtime_destroy(runtime: *mut c_void) {
 
 /// Allocates `svm_byte_array` to be used later for passing a binary [`Envelope`].
 ///
-/// The number of allocated bytes is a fixed, and it equals to [`svm_codec::envelope::byte_size()`](svm_codec::envelope::byte_size).
+/// The number of allocated bytes is equal to [`Envelope`]'s
+/// [`Codec::fixed_size()`].
 #[must_use]
 #[no_mangle]
 pub extern "C" fn svm_envelope_alloc() -> svm_byte_array {
@@ -156,7 +157,8 @@ pub extern "C" fn svm_envelope_alloc() -> svm_byte_array {
     svm_byte_array::with_capacity(size, ENVELOPE_TYPE)
 }
 
-/// Allocates `svm_byte_array` of `size` bytes, meant to be used for passing a binary [`Message`].
+/// Allocates `svm_byte_array` of `size` bytes, meant to be used for passing a
+/// binary message.
 #[must_use]
 #[no_mangle]
 pub extern "C" fn svm_message_alloc(size: u32) -> svm_byte_array {
@@ -165,7 +167,8 @@ pub extern "C" fn svm_message_alloc(size: u32) -> svm_byte_array {
 
 /// Allocates `svm_byte_array` to be used later for passing a binary [`Context`].
 ///
-/// The number of allocated bytes is a fixed, and it equals to [`svm_codec::context::byte_size()`](svm_codec::context::byte_size).
+/// The number of allocated bytes is equal to [`Context`]'s
+/// [`Codec::fixed_size()`].
 #[must_use]
 #[no_mangle]
 pub extern "C" fn svm_context_alloc() -> svm_byte_array {

--- a/crates/runtime-ffi/src/lib.rs
+++ b/crates/runtime-ffi/src/lib.rs
@@ -6,6 +6,7 @@
 #![deny(unused)]
 #![deny(dead_code)]
 #![deny(unreachable_code)]
+#![deny(rustdoc::broken_intra_doc_links)]
 #![feature(vec_into_raw_parts)]
 
 mod address;

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -7,6 +7,7 @@
 #![deny(unused)]
 #![warn(dead_code)]
 #![deny(unreachable_code)]
+#![deny(rustdoc::broken_intra_doc_links)]
 #![feature(vec_into_raw_parts)]
 
 mod env;

--- a/crates/sdk/alloc/src/lib.rs
+++ b/crates/sdk/alloc/src/lib.rs
@@ -8,6 +8,7 @@
 #![allow(unused)]
 #![allow(dead_code)]
 #![allow(unreachable_code)]
+#![deny(rustdoc::broken_intra_doc_links)]
 
 extern crate alloc;
 

--- a/crates/sdk/host/src/lib.rs
+++ b/crates/sdk/host/src/lib.rs
@@ -1,16 +1,16 @@
-#![no_std]
-#![feature(maybe_uninit_uninit_array)]
-#![feature(once_cell)]
-
 //! This crate implements SDK for SVM.
 //! Using this crate when writing SVM Templates in Rust isn't mandatory but should be very useful.
 //!
 //! The crate is compiled with `![no_std]` (no Rust standard-library) annotation in order to reduce the compiled WASM size.
 
+#![no_std]
 #![allow(missing_docs)]
 #![allow(unused)]
 #![allow(dead_code)]
 #![allow(unreachable_code)]
+#![deny(rustdoc::broken_intra_doc_links)]
+#![feature(maybe_uninit_uninit_array)]
+#![feature(once_cell)]
 
 pub mod traits;
 

--- a/crates/sdk/macros/src/lib.rs
+++ b/crates/sdk/macros/src/lib.rs
@@ -2,6 +2,7 @@
 #![allow(unused)]
 #![allow(dead_code)]
 #![allow(unreachable_code)]
+#![deny(rustdoc::broken_intra_doc_links)]
 
 mod function;
 mod json;

--- a/crates/sdk/std/src/lib.rs
+++ b/crates/sdk/std/src/lib.rs
@@ -16,11 +16,12 @@
 //! By introducing this crate we have full control of the emitted Wasm and we can cherry-pick only features that are relevant for us.
 
 #![no_std]
-#![feature(core_intrinsics)]
 #![deny(missing_docs)]
 #![deny(unused)]
 #![deny(dead_code)]
 #![deny(unreachable_code)]
+#![deny(rustdoc::broken_intra_doc_links)]
+#![feature(core_intrinsics)]
 
 mod log;
 pub use log::log;

--- a/crates/sdk/std/src/option.rs
+++ b/crates/sdk/std/src/option.rs
@@ -2,7 +2,8 @@ use core::cmp::{Eq, PartialEq};
 
 use crate::Result;
 
-/// Fixed-Gas replacement for [`std::option::Option`].
+/// Fixed-Gas replacement for
+/// [`std::option::Option`](https://doc.rust-lang.org/std/option/enum.Option.html).
 pub enum Option<T> {
     /// Represents Missing `value`
     None,

--- a/crates/sdk/std/src/string/mod.rs
+++ b/crates/sdk/std/src/string/mod.rs
@@ -8,7 +8,8 @@ pub use traits::ToString;
 
 use crate::Vec;
 
-/// Fixed-Gas replacement for [`std::string::String`].
+/// Fixed-Gas replacement for
+/// [`std::string::String`](https://doc.rust-lang.org/std/string/struct.String.html).
 pub enum String {
     /// A String longer than 8 bytes (data is stored on the `Heap`).
     Long(Vec<u8>),

--- a/crates/sdk/std/src/vec.rs
+++ b/crates/sdk/std/src/vec.rs
@@ -21,7 +21,8 @@ use core::ops::{Deref, DerefMut};
 
 use crate::ensure;
 
-/// Fixed-Gas replacement for [`std::vec::Vec`].
+/// Fixed-Gas replacement for
+/// [`std::vec::Vec`](https://doc.rust-lang.org/std/vec/struct.Vec.html).
 pub struct Vec<T> {
     len: usize,
     cap: usize,

--- a/crates/sdk/storage/src/lib.rs
+++ b/crates/sdk/storage/src/lib.rs
@@ -10,6 +10,7 @@
 #![allow(unused)]
 #![allow(dead_code)]
 #![allow(unreachable_code)]
+#![deny(rustdoc::broken_intra_doc_links)]
 
 mod ext;
 mod mock;

--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -9,6 +9,7 @@
 #![deny(unused)]
 #![deny(dead_code)]
 #![deny(unreachable_code)]
+#![deny(rustdoc::broken_intra_doc_links)]
 
 mod error;
 

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -2,6 +2,7 @@
 #![deny(unused)]
 #![deny(dead_code)]
 #![deny(unreachable_code)]
+#![deny(rustdoc::broken_intra_doc_links)]
 
 //! This crate is responsible on managing an `Account's storage.
 //!

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -5,6 +5,7 @@
 #![deny(unused)]
 #![deny(dead_code)]
 #![deny(unreachable_code)]
+#![deny(rustdoc::broken_intra_doc_links)]
 #![feature(const_type_id)]
 #![feature(const_type_name)]
 #![feature(vec_into_raw_parts)]


### PR DESCRIPTION
As per title. This is also checked by CI, which ensures that we can always build documentation for `master`.