### PR TITLE
Initializiting SVM's environment with `GlobalState` and replacing old storage layer logic

### DIFF
--- a/crates/runtime/src/env/mod.rs
+++ b/crates/runtime/src/env/mod.rs
@@ -3,10 +3,10 @@ use std::collections::{HashMap, HashSet};
 use std::io::Cursor;
 use std::rc::Rc;
 
+use svm_codec::template;
 use svm_codec::ParseError;
-use svm_codec::{template, Codec};
 use svm_gas::{resolvers, PriceResolver};
-use svm_types::{Address, SectionKind, SpawnAccount, Template, TemplateAddr, Transaction};
+use svm_types::{Address, SectionKind, Template, TemplateAddr};
 
 /// Default implementations
 mod default;
@@ -136,22 +136,6 @@ where
         let template = template::decode(cursor, interests)?;
 
         Ok(template)
-    }
-
-    /// Parses a binary [`SpawnAccount`] transaction.
-    ///
-    /// On success returns [`Spawn Account`],
-    /// On failure returns [`ParseError`].
-    pub fn parse_spawn(&self, bytes: &[u8]) -> Result<SpawnAccount, ParseError> {
-        SpawnAccount::decode_bytes(bytes)
-    }
-
-    /// Parses a binary `Call Account` (a.k.a a [`Transaction`]).
-    ///
-    /// On success returns [`Transaction`],
-    /// On failure returns [`ParseError`].
-    pub fn parse_call(&self, bytes: &[u8]) -> Result<Transaction, ParseError> {
-        Transaction::decode_bytes(bytes)
     }
 
     /// Saves a [`Template`] at the given [`TemplateAddr`].

--- a/crates/runtime/src/env/traits/store.rs
+++ b/crates/runtime/src/env/traits/store.rs
@@ -47,7 +47,7 @@ pub trait AccountStore {
 
 impl AccountStore for AccountStorage {
     fn store(&mut self, account: &ExtAccount, addr: &Address) {
-        let storage = AccountStorage::create(
+        AccountStorage::create(
             GlobalState::in_memory(),
             addr,
             account.name().to_string(),
@@ -61,16 +61,12 @@ impl AccountStore for AccountStorage {
     fn load(&self, addr: &Address) -> Option<ExtAccount> {
         let storage = AccountStorage::load(GlobalState::in_memory(), addr).unwrap();
 
-        Some(ExtAccount {
-            base: Account {
-                name: storage.name().unwrap().unwrap(),
-                template_addr: storage.template_addr().unwrap().unwrap(),
-            },
-            spawner: addr.clone(),
-        })
+        let account = Account::new(storage.template_addr().unwrap(), storage.name().unwrap());
+
+        Some(ExtAccount::new(&account, &addr))
     }
 
     fn resolve_template_addr(&self, addr: &Address) -> Option<TemplateAddr> {
-        self.template_addr().unwrap()
+        Some(self.load(addr)?.base().template_addr().clone())
     }
 }

--- a/crates/runtime/src/testing.rs
+++ b/crates/runtime/src/testing.rs
@@ -43,7 +43,7 @@ impl<'a> From<&'a [u8]> for WasmFile<'a> {
 }
 
 /// Creates an in-memory `Runtime` backed by a `state_kv`.
-pub fn create_memory_runtime() -> DefaultRuntime<DefaultMemEnvTypes> {
+pub fn create_memory_runtime() -> DefaultRuntime {
     let template_store = DefaultMemTemplateStore::new();
     let account_store = DefaultMemAccountStore::new();
     let env = Env::<DefaultMemEnvTypes>::new(account_store, template_store);

--- a/crates/runtime/tests/vmcalls_tests.rs
+++ b/crates/runtime/tests/vmcalls_tests.rs
@@ -121,12 +121,7 @@ fn vmcalls_get32_set32() {
     let layout: FixedLayout = vec![4, 2].into();
 
     let store = wasmer_store();
-    let storage = AccountStorage::new(
-        GlobalState::in_memory(),
-        &target_addr,
-        &template_addr,
-        &layout,
-    );
+    let storage = AccountStorage::load(GlobalState::in_memory(), &target_addr).unwrap();
     let envelope = Envelope::default();
     let context = Context::default();
     let func_env = FuncEnv::new(
@@ -168,12 +163,7 @@ fn vmcalls_get64_set64() {
     let layout: FixedLayout = vec![4, 2].into();
 
     let store = wasmer_store();
-    let storage = AccountStorage::new(
-        GlobalState::in_memory(),
-        &target_addr,
-        &template_addr,
-        &layout,
-    );
+    let storage = AccountStorage::load(GlobalState::in_memory(), &target_addr).unwrap();
     let envelope = Envelope::default();
     let context = Context::default();
     let func_env = FuncEnv::new(
@@ -216,12 +206,7 @@ fn vmcalls_load160() {
 
     let store = wasmer_store();
     let memory = wasmer_memory(&store);
-    let storage = AccountStorage::new(
-        GlobalState::in_memory(),
-        &target_addr,
-        &template_addr,
-        &layout,
-    );
+    let storage = AccountStorage::load(GlobalState::in_memory(), &target_addr).unwrap();
     let envelope = Envelope::default();
     let context = Context::default();
     let func_env = FuncEnv::new_with_memory(
@@ -274,12 +259,7 @@ fn vmcalls_store160() {
 
     let store = wasmer_store();
     let memory = wasmer_memory(&store);
-    let storage = AccountStorage::new(
-        GlobalState::in_memory(),
-        &target_addr,
-        &template_addr,
-        &layout,
-    );
+    let storage = AccountStorage::load(GlobalState::in_memory(), &target_addr).unwrap();
     let envelope = Envelope::default();
     let context = Context::default();
     let func_env = FuncEnv::new_with_memory(
@@ -327,12 +307,7 @@ fn vmcalls_log() {
 
     let store = wasmer_store();
     let memory = wasmer_memory(&store);
-    let storage = AccountStorage::new(
-        GlobalState::in_memory(),
-        &target_addr,
-        &template_addr,
-        &layout,
-    );
+    let storage = AccountStorage::load(GlobalState::in_memory(), &target_addr).unwrap();
     let envelope = Envelope::default();
     let context = Context::default();
     let func_env = FuncEnv::new_with_memory(

--- a/crates/state/src/template_storage.rs
+++ b/crates/state/src/template_storage.rs
@@ -8,7 +8,8 @@ pub struct TemplateStorage {
     /// The internal [`GlobalState`] instance used to access the database layer.
     pub gs: GlobalState,
 
-    template_addr: TemplateAddr,
+    /// The [`TemplateAddr`] of `self`.
+    pub addr: TemplateAddr,
 }
 
 impl TemplateStorage {
@@ -16,19 +17,17 @@ impl TemplateStorage {
     /// [`GlobalState`] instance.
     pub fn new(template_addr: &TemplateAddr, gs: GlobalState) -> Self {
         Self {
-            template_addr: template_addr.clone(),
+            addr: template_addr.clone(),
             gs,
         }
     }
 
     /// Reads, decodes and finally returns all [`Sections`] of `self`.
     pub fn sections(&self) -> StorageResult<Option<Sections>> {
-        let core = self
-            .gs
-            .read_and_decode::<Sections>(&key_core(&self.template_addr))?;
+        let core = self.gs.read_and_decode::<Sections>(&key_core(&self.addr))?;
         let noncore = self
             .gs
-            .read_and_decode::<Sections>(&key_noncore(&self.template_addr))?;
+            .read_and_decode::<Sections>(&key_noncore(&self.addr))?;
 
         match (core, noncore) {
             (Some(mut sections), Some(noncore)) => {
@@ -44,7 +43,7 @@ impl TemplateStorage {
     /// Overwrites the "core" (mandatory) [`Sections`] associated with
     /// `self`.
     pub fn set_core(&mut self, sections: &Sections) -> StorageResult<()> {
-        let key = key_core(&self.template_addr);
+        let key = key_core(&self.addr);
         self.gs.encode_and_write(sections, &key);
 
         Ok(())
@@ -53,7 +52,7 @@ impl TemplateStorage {
     /// Overwrites the "non-core" (optional) [`Sections`] associated with
     /// `self`.
     pub fn set_noncore(&mut self, sections: &Sections) -> StorageResult<()> {
-        let key = key_noncore(&self.template_addr);
+        let key = key_noncore(&self.addr);
         self.gs.encode_and_write(sections, &key);
 
         Ok(())


### PR DESCRIPTION
As per title.

This PR requires significant changes to the old storage layer logic (`Env`), which is now replaced by `svm_state::GlobalState`. We also want to remove the old `default-rocksdb` feature flag. At the moment, we're currently using SQLite, which can easily exist in memory, and thus doesn't require mocking. I propose that, if we ever decided to come back to RocksDB for performance reasons, we use temporary file storage rather than mocking, which would unify code paths and likely remove reduce bugs due to inconsistent behavior in testing/production.