### PR TITLE
Remove the `svm_abi_layout::layout` module

### DIFF
--- a/crates/abi-decoder/src/decoder.rs
+++ b/crates/abi-decoder/src/decoder.rs
@@ -1,4 +1,4 @@
-use svm_abi_layout::layout;
+use svm_abi_layout as layout;
 use svm_sdk_std::{safe_try, Result, Vec};
 use svm_sdk_types::value::{Primitive, Value};
 use svm_sdk_types::{Address, Amount};

--- a/crates/abi-encoder/src/types/address.rs
+++ b/crates/abi-encoder/src/types/address.rs
@@ -1,5 +1,4 @@
 use seq_macro::seq;
-use svm_abi_layout::layout;
 use svm_sdk_types::Address;
 
 use crate::traits::Push;
@@ -10,7 +9,8 @@ where
     W: Push<Item = u8>,
 {
     fn encode(&self, w: &mut W) {
-        w.push(layout::ADDRESS);
+        w.push(svm_abi_layout::ADDRESS);
+
         let bytes = self.as_slice();
         seq!(N in 0..20 {
             w.push(bytes[N]);

--- a/crates/abi-encoder/src/types/boolean.rs
+++ b/crates/abi-encoder/src/types/boolean.rs
@@ -1,4 +1,4 @@
-use svm_abi_layout::layout;
+use svm_abi_layout as layout;
 
 use crate::{traits::Push, ByteSize, Encoder};
 

--- a/crates/abi-encoder/src/types/numeric.rs
+++ b/crates/abi-encoder/src/types/numeric.rs
@@ -105,9 +105,11 @@ impl Numeric for u64 {
 /// Integer layout marker bytes generator. It looks scary, but all it does is it
 /// dynamically encodes the layout formula specificied by the ABI.
 pub fn layout_integer(max_width_in_bytes: u32, width_in_bytes: u32, signed: bool) -> u8 {
-    use svm_abi_layout::layout::*;
+    use svm_abi_layout::*;
+
     debug_assert!(width_in_bytes <= max_width_in_bytes);
     debug_assert!(max_width_in_bytes <= 8);
+
     match (max_width_in_bytes, (width_in_bytes - 1) as u8, signed) {
         (1, 0, true) => I8,
         (1, 0, false) => U8,
@@ -124,7 +126,7 @@ pub fn layout_integer(max_width_in_bytes: u32, width_in_bytes: u32, signed: bool
 #[cfg(test)]
 mod test {
     use super::*;
-    use svm_abi_layout::layout;
+    use svm_abi_layout as layout;
 
     #[test]
     fn integer_layouts() {

--- a/crates/abi-encoder/src/types/option.rs
+++ b/crates/abi-encoder/src/types/option.rs
@@ -10,9 +10,7 @@ where
     fn encode(&self, w: &mut W) {
         match self {
             svm_sdk_std::Option::None => {
-                use svm_abi_layout::layout;
-
-                w.push(layout::NONE);
+                w.push(svm_abi_layout::NONE);
             }
             svm_sdk_std::Option::Some(val) => val.encode(w),
         }

--- a/crates/abi-encoder/src/types/unit.rs
+++ b/crates/abi-encoder/src/types/unit.rs
@@ -1,5 +1,3 @@
-use svm_abi_layout::layout;
-
 use crate::{traits::Push, ByteSize, Encoder};
 
 impl<W> Encoder<W> for ()
@@ -7,7 +5,7 @@ where
     W: Push<Item = u8>,
 {
     fn encode(&self, w: &mut W) {
-        w.push(layout::UNIT);
+        w.push(svm_abi_layout::UNIT);
     }
 }
 

--- a/crates/abi-layout/src/lib.rs
+++ b/crates/abi-layout/src/lib.rs
@@ -76,89 +76,70 @@
 #![deny(dead_code)]
 #![deny(unreachable_code)]
 #![deny(rustdoc::broken_intra_doc_links)]
+#![allow(clippy::unusual_byte_groupings)]
+#![allow(missing_docs)]
 
-#[allow(clippy::unusual_byte_groupings)]
-#[doc(hidden)]
-pub mod layout {
-    // Boolean
-    pub const BOOL_FALSE: u8 = 0b_0_000_0000;
-    pub const BOOL_TRUE: u8 = 0b_0_001_0000;
+pub const BOOL_FALSE: u8 = 0b_0_000_0000;
+pub const BOOL_TRUE: u8 = 0b_0_001_0000;
 
-    // None
-    pub const NONE: u8 = 0b_0_010_0000;
+pub const NONE: u8 = 0b_0_010_0000;
 
-    // Unit
-    pub const UNIT: u8 = 0b_0_011_0000;
+pub const UNIT: u8 = 0b_0_011_0000;
 
-    // Address
-    pub const ADDRESS: u8 = 0b_0_100_0000;
+pub const ADDRESS: u8 = 0b_0_100_0000;
 
-    /// Amount
-    pub const AMOUNT_1B: u8 = 0b_0_000_0001;
-    pub const AMOUNT_2B: u8 = 0b_0_001_0001;
-    pub const AMOUNT_3B: u8 = 0b_0_010_0001;
-    pub const AMOUNT_4B: u8 = 0b_0_011_0001;
-    pub const AMOUNT_5B: u8 = 0b_0_100_0001;
-    pub const AMOUNT_6B: u8 = 0b_0_101_0001;
-    pub const AMOUNT_7B: u8 = 0b_0_110_0001;
-    pub const AMOUNT_8B: u8 = 0b_0_111_0001;
+pub const AMOUNT_1B: u8 = 0b_0_000_0001;
+pub const AMOUNT_2B: u8 = 0b_0_001_0001;
+pub const AMOUNT_3B: u8 = 0b_0_010_0001;
+pub const AMOUNT_4B: u8 = 0b_0_011_0001;
+pub const AMOUNT_5B: u8 = 0b_0_100_0001;
+pub const AMOUNT_6B: u8 = 0b_0_101_0001;
+pub const AMOUNT_7B: u8 = 0b_0_110_0001;
+pub const AMOUNT_8B: u8 = 0b_0_111_0001;
 
-    // i8
-    //// signed
-    pub const I8: u8 = 0b_0_000_0010;
-    /// unsigned
-    pub const U8: u8 = 0b_0_001_0010;
+pub const I8: u8 = 0b_0_000_0010;
+pub const U8: u8 = 0b_0_001_0010;
 
-    // i16
-    //// signed
-    pub const I16_1B: u8 = 0b_0_010_0010;
-    pub const I16_2B: u8 = 0b_0_011_0010;
-    //// unsigned
-    pub const U16_1B: u8 = 0b_0_100_0010;
-    pub const U16_2B: u8 = 0b_0_101_0010;
+pub const I16_1B: u8 = 0b_0_010_0010;
+pub const I16_2B: u8 = 0b_0_011_0010;
+pub const U16_1B: u8 = 0b_0_100_0010;
+pub const U16_2B: u8 = 0b_0_101_0010;
 
-    // i32
-    //// signed
-    pub const I32_1B: u8 = 0b_0_000_0011;
-    pub const I32_2B: u8 = 0b_0_001_0011;
-    pub const I32_3B: u8 = 0b_0_010_0011;
-    pub const I32_4B: u8 = 0b_0_011_0011;
-    //// unsigned
-    pub const U32_1B: u8 = 0b_0_100_0011;
-    pub const U32_2B: u8 = 0b_0_101_0011;
-    pub const U32_3B: u8 = 0b_0_110_0011;
-    pub const U32_4B: u8 = 0b_0_111_0011;
+pub const I32_1B: u8 = 0b_0_000_0011;
+pub const I32_2B: u8 = 0b_0_001_0011;
+pub const I32_3B: u8 = 0b_0_010_0011;
+pub const I32_4B: u8 = 0b_0_011_0011;
+pub const U32_1B: u8 = 0b_0_100_0011;
+pub const U32_2B: u8 = 0b_0_101_0011;
+pub const U32_3B: u8 = 0b_0_110_0011;
+pub const U32_4B: u8 = 0b_0_111_0011;
 
-    // i64
-    //// signed
-    pub const I64_1B: u8 = 0b_0_000_0100;
-    pub const I64_2B: u8 = 0b_0_001_0100;
-    pub const I64_3B: u8 = 0b_0_010_0100;
-    pub const I64_4B: u8 = 0b_0_011_0100;
-    pub const I64_5B: u8 = 0b_0_100_0100;
-    pub const I64_6B: u8 = 0b_0_101_0100;
-    pub const I64_7B: u8 = 0b_0_110_0100;
-    pub const I64_8B: u8 = 0b_0_111_0100;
-    //// unsigned
-    pub const U64_1B: u8 = 0b_0_000_0101;
-    pub const U64_2B: u8 = 0b_0_001_0101;
-    pub const U64_3B: u8 = 0b_0_010_0101;
-    pub const U64_4B: u8 = 0b_0_011_0101;
-    pub const U64_5B: u8 = 0b_0_100_0101;
-    pub const U64_6B: u8 = 0b_0_101_0101;
-    pub const U64_7B: u8 = 0b_0_110_0101;
-    pub const U64_8B: u8 = 0b_0_111_0101;
+pub const I64_1B: u8 = 0b_0_000_0100;
+pub const I64_2B: u8 = 0b_0_001_0100;
+pub const I64_3B: u8 = 0b_0_010_0100;
+pub const I64_4B: u8 = 0b_0_011_0100;
+pub const I64_5B: u8 = 0b_0_100_0100;
+pub const I64_6B: u8 = 0b_0_101_0100;
+pub const I64_7B: u8 = 0b_0_110_0100;
+pub const I64_8B: u8 = 0b_0_111_0100;
+pub const U64_1B: u8 = 0b_0_000_0101;
+pub const U64_2B: u8 = 0b_0_001_0101;
+pub const U64_3B: u8 = 0b_0_010_0101;
+pub const U64_4B: u8 = 0b_0_011_0101;
+pub const U64_5B: u8 = 0b_0_100_0101;
+pub const U64_6B: u8 = 0b_0_101_0101;
+pub const U64_7B: u8 = 0b_0_110_0101;
+pub const U64_8B: u8 = 0b_0_111_0101;
 
-    // Small-Array
-    pub const ARR_0: u8 = 0b_0_000_0110;
-    pub const ARR_1: u8 = 0b_0_001_0110;
-    pub const ARR_2: u8 = 0b_0_010_0110;
-    pub const ARR_3: u8 = 0b_0_011_0110;
-    pub const ARR_4: u8 = 0b_0_100_0110;
-    pub const ARR_5: u8 = 0b_0_101_0110;
-    pub const ARR_6: u8 = 0b_0_110_0110;
-    pub const ARR_7: u8 = 0b_0_111_0110;
-    pub const ARR_8: u8 = 0b_0_000_0111;
-    pub const ARR_9: u8 = 0b_0_001_0111;
-    pub const ARR_10: u8 = 0b_0_010_0111;
-}
+// Small arrays.
+pub const ARR_0: u8 = 0b_0_000_0110;
+pub const ARR_1: u8 = 0b_0_001_0110;
+pub const ARR_2: u8 = 0b_0_010_0110;
+pub const ARR_3: u8 = 0b_0_011_0110;
+pub const ARR_4: u8 = 0b_0_100_0110;
+pub const ARR_5: u8 = 0b_0_101_0110;
+pub const ARR_6: u8 = 0b_0_110_0110;
+pub const ARR_7: u8 = 0b_0_111_0110;
+pub const ARR_8: u8 = 0b_0_000_0111;
+pub const ARR_9: u8 = 0b_0_001_0111;
+pub const ARR_10: u8 = 0b_0_010_0111;


### PR DESCRIPTION
As per title. I think it's there for historical reasons, but now it's just nested hierarchy for no reasons.