### PR TITLE
Change the install name of macOS artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
         run: |
           set -e
           install_name_tool -id libsvm.dylib bins/${{ matrix.lib_name }}.${{ matrix.shared }}
-          sudo cp bins/${{ matrix.lib_name }}.${{ matrix.shared }} /usr/lib/${{ matrix.lib_name }}.${{ matrix.shared }}
+          cp bins/${{ matrix.lib_name }}.${{ matrix.shared }} /usr/local/lib/
       - name: Upload Artifacts
         uses: actions/upload-artifact@master
         with:


### PR DESCRIPTION
Attempts a fix from https://stackoverflow.com/questions/35220111/install-name-tool-difference-between-change-and-id to change the install name of `dylib` artifact on macOS.