### PR TITLE
Invalid `ctor`: `FuncNotAllowed` is now `FuncNotFound`

### DIFF
--- a/crates/runtime/src/runtime/runtime.rs
+++ b/crates/runtime/src/runtime/runtime.rs
@@ -576,11 +576,10 @@ impl Runtime {
             let account_addr = compute_account_addr(&spawn);
 
             return SpawnReceipt::from_err(
-                RuntimeError::FuncNotAllowed {
+                RuntimeError::FuncNotFound {
                     target: account_addr,
                     template: account.template_addr().clone(),
                     func: spawn.ctor_name().to_string(),
-                    msg: "The given function is not a `ctor`.".to_string(),
                 },
                 vec![],
             );

--- a/crates/runtime/tests/runtime_tests.rs
+++ b/crates/runtime/tests/runtime_tests.rs
@@ -228,7 +228,7 @@ fn memory_runtime_spawn_invoking_non_ctor_fails() {
 
     assert!(matches!(
         receipt.error.unwrap(),
-        RuntimeError::FuncNotAllowed { .. }
+        RuntimeError::FuncNotFound { .. }
     ));
 }
 


### PR DESCRIPTION
When spawning with an invalid `ctor`, we previously returned a `FuncNotAllowed` error. The reasoning was, it's possible that the selected function exists but isn't actually allowed to run as a `ctor`. I think `FuncNotFound` makes more sense though.