### PR TITLE
Touched accounts

### DIFF
--- a/crates/codec/src/api/json/mod.rs
+++ b/crates/codec/src/api/json/mod.rs
@@ -4,7 +4,7 @@ mod call;
 mod error;
 mod inputdata;
 mod receipt;
-mod serde_types;
+pub(crate) mod serde_types;
 mod spawn;
 
 pub use call::{decode_call, encode_call, encode_call_raw};

--- a/crates/codec/src/api/json/receipt.rs
+++ b/crates/codec/src/api/json/receipt.rs
@@ -263,7 +263,7 @@ mod tests {
             ReceiptLog::new(b"Log entry #2".to_vec()),
         ];
 
-        let receipt = SpawnReceipt {
+        let mut receipt = SpawnReceipt {
             version: 0,
             success: true,
             error: None,
@@ -274,6 +274,7 @@ mod tests {
             touched_accounts: HashSet::new(),
             logs,
         };
+        receipt.touched_accounts.insert(account);
 
         let bytes = receipt.encode_to_vec();
         let data = HexBlob(&bytes);
@@ -288,7 +289,7 @@ mod tests {
                 "gas_used": 10,
                 "returndata": "102030",
                 "state": "A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0",
-                "touched_accounts": [],
+                "touched_accounts": ["1010101010101010101010101010101010101010"],
                 "logs": [
                     {"data": "Log entry #1"},
                     {"data": "Log entry #2"}

--- a/crates/codec/src/api/json/receipt.rs
+++ b/crates/codec/src/api/json/receipt.rs
@@ -166,6 +166,7 @@ fn decode_spawn(receipt: &SpawnReceipt, ty: &'static str) -> Value {
         returndata,
         gas_used,
         logs,
+        touched_accounts,
         ..
     } = receipt;
 
@@ -176,6 +177,7 @@ fn decode_spawn(receipt: &SpawnReceipt, ty: &'static str) -> Value {
         "state": HexBlob(init_state.as_ref().unwrap().as_slice()),
         "returndata": HexBlob(returndata.as_ref().unwrap()),
         "gas_used": json::gas_to_json(&gas_used),
+        "touched_accounts": touched_accounts.into_iter().map(|addr| AddressWrapper(*addr)).collect::<Vec<AddressWrapper>>(),
         "logs": json::logs_to_json(&logs),
     })
 }
@@ -189,6 +191,7 @@ fn decode_call(receipt: &CallReceipt, ty: &'static str) -> Value {
         returndata,
         gas_used,
         logs,
+        touched_accounts,
         ..
     } = receipt;
 
@@ -198,12 +201,15 @@ fn decode_call(receipt: &CallReceipt, ty: &'static str) -> Value {
         "new_state": HexBlob(new_state.as_ref().unwrap().as_slice()),
         "returndata": HexBlob(returndata.as_ref().unwrap()),
         "gas_used": json::gas_to_json(&gas_used),
+        "touched_accounts": touched_accounts.into_iter().map(|addr| AddressWrapper(*addr)).collect::<Vec<AddressWrapper>>(),
         "logs": json::logs_to_json(&logs),
     })
 }
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+
     use crate::Codec;
 
     use super::*;
@@ -265,6 +271,7 @@ mod tests {
             init_state: Some(state),
             returndata: Some(vec![0x10, 0x20, 0x30]),
             gas_used: Gas::with(10),
+            touched_accounts: HashSet::new(),
             logs,
         };
 
@@ -281,6 +288,7 @@ mod tests {
                 "gas_used": 10,
                 "returndata": "102030",
                 "state": "A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0",
+                "touched_accounts": [],
                 "logs": [
                     {"data": "Log entry #1"},
                     {"data": "Log entry #2"}
@@ -301,6 +309,7 @@ mod tests {
             init_state: None,
             returndata: None,
             gas_used: Gas::with(1000),
+            touched_accounts: HashSet::new(),
             logs,
         };
 
@@ -335,6 +344,7 @@ mod tests {
             new_state: Some(state),
             returndata: Some(vec![0x10, 0x20]),
             gas_used: Gas::with(10),
+            touched_accounts: HashSet::new(),
             logs,
         };
 
@@ -350,6 +360,7 @@ mod tests {
                 "gas_used": 10,
                 "returndata": "1020",
                 "new_state": "A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0",
+                "touched_accounts": [],
                 "logs": [
                     {"data": "Log entry #1"},
                     {"data": "Log entry #2"}

--- a/crates/codec/src/receipt/mod.rs
+++ b/crates/codec/src/receipt/mod.rs
@@ -4,6 +4,7 @@ mod call;
 mod deploy;
 mod error;
 mod spawn;
+mod touched_accounts;
 
 pub(crate) mod logs;
 

--- a/crates/codec/src/receipt/touched_accounts.rs
+++ b/crates/codec/src/receipt/touched_accounts.rs
@@ -1,0 +1,28 @@
+use std::collections::HashSet;
+
+use svm_types::{Address, BytesPrimitive};
+
+use crate::{Codec, ParseError, ReadExt, WriteExt};
+
+impl Codec for HashSet<Address> {
+    type Error = ParseError;
+
+    fn encode(&self, w: &mut impl WriteExt) {
+        u16::try_from(self.len()).unwrap().encode(w);
+
+        for addr in self.iter() {
+            w.write_bytes(addr.as_slice());
+        }
+    }
+
+    fn decode(cursor: &mut impl ReadExt) -> std::result::Result<Self, Self::Error> {
+        let len = u16::decode(cursor)?;
+        let mut touched_accounts = HashSet::new();
+
+        for _ in 0..len {
+            touched_accounts.insert(Address::new(cursor.read_bytes(20)?));
+        }
+
+        Ok(touched_accounts)
+    }
+}

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -22,5 +22,5 @@ pub mod vmcalls;
 pub use error::ValidateError;
 pub use func_env::{FuncEnv, ProtectedMode};
 pub use price_registry::PriceResolverRegistry;
-pub use runtime::Runtime;
+pub use runtime::{compute_account_addr, compute_template_addr, Runtime};
 pub use wasm_store::new_store;

--- a/crates/runtime/src/runtime/function.rs
+++ b/crates/runtime/src/runtime/function.rs
@@ -9,9 +9,7 @@ where
     Rets: WasmTypeList,
 {
     func: &'a wasmer::Function,
-
     name: &'a str,
-
     phantom: PhantomData<(Args, Rets)>,
 }
 

--- a/crates/runtime/src/runtime/mod.rs
+++ b/crates/runtime/src/runtime/mod.rs
@@ -8,4 +8,4 @@ mod runtime;
 pub use call::Call;
 pub use function::Function;
 pub use outcome::Outcome;
-pub use runtime::Runtime;
+pub use runtime::{compute_account_addr, compute_template_addr, Runtime};

--- a/crates/runtime/src/runtime/runtime.rs
+++ b/crates/runtime/src/runtime/runtime.rs
@@ -813,8 +813,6 @@ fn commit_changes(env: &FuncEnv) -> State {
 }
 
 fn outcome_to_receipt(env: &FuncEnv, mut out: Outcome<Box<[wasmer::Val]>>) -> CallReceipt {
-    let mut touched_accounts = HashSet::new();
-    touched_accounts.insert(env.target_addr().clone());
     CallReceipt {
         version: 0,
         success: true,
@@ -822,7 +820,7 @@ fn outcome_to_receipt(env: &FuncEnv, mut out: Outcome<Box<[wasmer::Val]>>) -> Ca
         returndata: Some(take_returndata(env)),
         new_state: Some(commit_changes(&env)),
         gas_used: out.gas_used(),
-        touched_accounts,
+        touched_accounts: env.borrow().touched_accounts(),
         logs: out.take_logs(),
     }
 }

--- a/crates/runtime/src/runtime/runtime.rs
+++ b/crates/runtime/src/runtime/runtime.rs
@@ -3,7 +3,7 @@ use svm_codec::Codec;
 use wasmer::{Instance, Module, WasmPtr, WasmTypeList};
 
 use std::cell::RefCell;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 
 use svm_gas::{FuncPrice, ProgramPricing};
@@ -813,6 +813,8 @@ fn commit_changes(env: &FuncEnv) -> State {
 }
 
 fn outcome_to_receipt(env: &FuncEnv, mut out: Outcome<Box<[wasmer::Val]>>) -> CallReceipt {
+    let mut touched_accounts = HashSet::new();
+    touched_accounts.insert(env.target_addr().clone());
     CallReceipt {
         version: 0,
         success: true,
@@ -820,6 +822,7 @@ fn outcome_to_receipt(env: &FuncEnv, mut out: Outcome<Box<[wasmer::Val]>>) -> Ca
         returndata: Some(take_returndata(env)),
         new_state: Some(commit_changes(&env)),
         gas_used: out.gas_used(),
+        touched_accounts,
         logs: out.take_logs(),
     }
 }

--- a/crates/state/src/account_storage.rs
+++ b/crates/state/src/account_storage.rs
@@ -17,7 +17,8 @@ pub struct AccountStorage {
     /// The internal [`GlobalState`] instance used to access the database layer.
     pub gs: GlobalState,
 
-    address: Address,
+    /// The owner's [`Address`] of this [`AccountStorage`].
+    pub address: Address,
     template_addr: TemplateAddr,
     layout: FixedLayout,
 }

--- a/crates/types/src/receipt/call.rs
+++ b/crates/types/src/receipt/call.rs
@@ -1,6 +1,8 @@
+use std::collections::HashSet;
+
 use crate::gas::Gas;
 use crate::receipt::{ReceiptLog, RuntimeError};
-use crate::State;
+use crate::{Address, State};
 
 /// Runtime transaction execution receipt
 #[derive(Debug, PartialEq, Clone)]
@@ -22,6 +24,9 @@ pub struct CallReceipt {
 
     /// The amount of gas used.
     pub gas_used: Gas,
+
+    /// A set of accounts that have changed balance, or *might* have.
+    pub touched_accounts: HashSet<Address>,
 
     /// Logs generated during execution of the transaction.
     pub logs: Vec<ReceiptLog>,
@@ -48,6 +53,7 @@ impl CallReceipt {
             new_state: None,
             returndata: None,
             gas_used: Gas::new(),
+            touched_accounts: HashSet::new(),
             logs,
         }
     }

--- a/crates/types/src/receipt/spawn.rs
+++ b/crates/types/src/receipt/spawn.rs
@@ -130,7 +130,7 @@ pub fn into_spawn_receipt(mut ctor_receipt: CallReceipt, account_addr: &Address)
             init_state: None,
             returndata: None,
             gas_used: Gas::new(),
-            touched_accounts: ctor_receipt.touched_accounts,
+            touched_accounts: HashSet::new(),
             logs,
         }
     }

--- a/crates/types/src/receipt/spawn.rs
+++ b/crates/types/src/receipt/spawn.rs
@@ -130,7 +130,7 @@ pub fn into_spawn_receipt(mut ctor_receipt: CallReceipt, account_addr: &Address)
             init_state: None,
             returndata: None,
             gas_used: Gas::new(),
-            touched_accounts: HashSet::new(),
+            touched_accounts: ctor_receipt.touched_accounts,
             logs,
         }
     }

--- a/crates/types/src/receipt/spawn.rs
+++ b/crates/types/src/receipt/spawn.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use crate::{Address, Gas, State};
 use crate::{CallReceipt, ReceiptLog, RuntimeError};
 
@@ -25,6 +27,9 @@ pub struct SpawnReceipt {
     /// The amount of gas used.
     pub gas_used: Gas,
 
+    /// A set of accounts that have changed balance, or *might* have.
+    pub touched_accounts: HashSet<Address>,
+
     /// Logs collected during `Spawning` `ctor` running.
     pub logs: Vec<ReceiptLog>,
 }
@@ -45,6 +50,7 @@ impl SpawnReceipt {
             init_state: None,
             returndata: None,
             gas_used: Gas::new(),
+            touched_accounts: HashSet::new(),
             logs,
         }
     }
@@ -110,6 +116,7 @@ pub fn into_spawn_receipt(mut ctor_receipt: CallReceipt, account_addr: &Address)
             init_state: ctor_receipt.new_state,
             returndata: ctor_receipt.returndata,
             gas_used: ctor_receipt.gas_used,
+            touched_accounts: ctor_receipt.touched_accounts,
             logs,
         }
     } else {
@@ -123,6 +130,7 @@ pub fn into_spawn_receipt(mut ctor_receipt: CallReceipt, account_addr: &Address)
             init_state: None,
             returndata: None,
             gas_used: Gas::new(),
+            touched_accounts: HashSet::new(),
             logs,
         }
     }


### PR DESCRIPTION
Closes https://github.com/spacemeshos/svm/issues/375.

This PR adds a `touched_accounts` field to both `SpawnReceipt` and `CallReceipt`. This is a set of account addresses that includes the following:

- Principal account address.
- Newly spawned account address (only for `spawn`).
- Any other address involved in a coin transfer during smart contract execution.