### PR TITLE
Runtime refactoring

### DIFF
--- a/crates/codec/src/api/json/receipt.rs
+++ b/crates/codec/src/api/json/receipt.rs
@@ -99,6 +99,14 @@ fn decode_error(ty: &'static str, err: &RuntimeError, logs: &[ReceiptLog]) -> Va
                 "func": func,
                 "message": msg,
             }),
+            RuntimeError::FuncNotCtor {
+                template: template_addr,
+                func,
+            } => json!({
+                "err_type": "function-not-ctor",
+                "template_addr": TemplateAddrWrapper::from(*template_addr),
+                "func": func,
+            }),
             RuntimeError::FuncNotAllowed {
                 target: account_addr,
                 template: template_addr,

--- a/crates/runtime-ffi/src/api.rs
+++ b/crates/runtime-ffi/src/api.rs
@@ -76,12 +76,7 @@ pub unsafe extern "C" fn svm_runtime_create(
             GlobalState::new(std::str::from_utf8(db_path).expect("Invalid UTF-8 path."))
         };
 
-        let runtime = Runtime::new(
-            imports,
-            global_state,
-            PriceResolverRegistry::default(),
-            None,
-        );
+        let runtime = Runtime::new(imports, global_state, PriceResolverRegistry::default());
 
         *runtime_ptr = RUNTIME_TRACKER.alloc(runtime);
         debug!("`svm_runtime_create` end");

--- a/crates/runtime-ffi/src/api.rs
+++ b/crates/runtime-ffi/src/api.rs
@@ -10,7 +10,7 @@ use std::slice;
 use svm_codec::Codec;
 use svm_runtime::{PriceResolverRegistry, Runtime, TemplatePriceCache, ValidateError};
 use svm_state::GlobalState;
-use svm_types::{Address, BytesPrimitive, Context, Envelope, Layer, State};
+use svm_types::{Address, BytesPrimitive, Context, Envelope, Layer, State, TemplateAddr};
 
 use crate::resource_tracker::ResourceTracker;
 use crate::svm_result_t;
@@ -552,8 +552,16 @@ pub unsafe extern "C" fn svm_create_account(
     catch_unwind_or_fail(|| {
         let runtime = RUNTIME_TRACKER.get(runtime_ptr).unwrap();
         let account_addr = Address::new(slice::from_raw_parts(addr, Address::N));
+        let template_addr = TemplateAddr::god_template();
         let counter = ((counter_upper_bits as u128) << 64) | (counter_lower_bits as u128);
-        runtime.create_account(&account_addr, "".to_string(), balance, counter)?;
+
+        runtime.create_account(
+            &account_addr,
+            &template_addr,
+            "".to_string(),
+            balance,
+            counter,
+        )?;
 
         svm_result_t::OK
     })

--- a/crates/runtime-ffi/src/api.rs
+++ b/crates/runtime-ffi/src/api.rs
@@ -10,7 +10,7 @@ use std::slice;
 use svm_codec::Codec;
 use svm_runtime::{PriceResolverRegistry, Runtime, TemplatePriceCache, ValidateError};
 use svm_state::GlobalState;
-use svm_types::{Address, BytesPrimitive, Context, Envelope, Layer, State, TemplateAddr};
+use svm_types::{Address, BytesPrimitive, Context, Envelope, Layer, State};
 
 use crate::resource_tracker::ResourceTracker;
 use crate::svm_result_t;
@@ -542,7 +542,7 @@ pub unsafe extern "C" fn svm_get_account(
 /// Creates an account at genesis with a given balance and nonce counter.
 #[no_mangle]
 #[must_use]
-pub unsafe extern "C" fn svm_create_account(
+pub unsafe extern "C" fn svm_create_genesis_account(
     runtime_ptr: *mut c_void,
     addr: *const u8,
     balance: u64,
@@ -552,16 +552,8 @@ pub unsafe extern "C" fn svm_create_account(
     catch_unwind_or_fail(|| {
         let runtime = RUNTIME_TRACKER.get(runtime_ptr).unwrap();
         let account_addr = Address::new(slice::from_raw_parts(addr, Address::N));
-        let template_addr = TemplateAddr::god_template();
         let counter = ((counter_upper_bits as u128) << 64) | (counter_lower_bits as u128);
-
-        runtime.create_account(
-            &account_addr,
-            &template_addr,
-            "".to_string(),
-            balance,
-            counter,
-        )?;
+        runtime.create_genesis_account(&account_addr, "".to_string(), balance, counter)?;
 
         svm_result_t::OK
     })

--- a/crates/runtime-ffi/tests/api_tests.rs
+++ b/crates/runtime-ffi/tests/api_tests.rs
@@ -222,8 +222,8 @@ fn svm_transfer_success() {
         let mut runtime = std::ptr::null_mut();
 
         api::svm_runtime_create(&mut runtime, std::ptr::null(), 0).unwrap();
-        api::svm_create_account(runtime, src_addr.as_slice().as_ptr(), 1000, 0, 0).unwrap();
-        api::svm_create_account(runtime, dst_addr.as_slice().as_ptr(), 0, 0, 0).unwrap();
+        api::svm_create_genesis_account(runtime, src_addr.as_slice().as_ptr(), 1000, 0, 0).unwrap();
+        api::svm_create_genesis_account(runtime, dst_addr.as_slice().as_ptr(), 0, 0, 0).unwrap();
         api::svm_transfer(
             runtime,
             src_addr.as_slice().as_ptr(),

--- a/crates/runtime/src/func_env.rs
+++ b/crates/runtime/src/func_env.rs
@@ -39,7 +39,7 @@ impl FuncEnv {
             envelope: envelope.clone(),
             context: context.clone(),
         };
-        env.set_protected_mode(mode);
+        env.set_access_mode(mode);
 
         env
     }
@@ -86,7 +86,7 @@ impl FuncEnv {
     }
 
     /// Sets the [`AccessMode`] and overrides the existing value.
-    pub fn set_protected_mode(&self, mode: AccessMode) {
+    pub fn set_access_mode(&self, mode: AccessMode) {
         let mut borrow = self.borrow_mut();
         borrow.set_access_mode(mode);
     }

--- a/crates/runtime/src/func_env.rs
+++ b/crates/runtime/src/func_env.rs
@@ -85,14 +85,14 @@ impl FuncEnv {
             .expect("Attempted write but RwLock is poisoned")
     }
 
-    /// Sets the [`ProtectedMode`] and overrides the existing value.
+    /// Sets the [`AccessMode`] and overrides the existing value.
     pub fn set_protected_mode(&self, mode: AccessMode) {
         let mut borrow = self.borrow_mut();
         borrow.set_access_mode(mode);
     }
 
-    /// Returns the current [`ProtectedMode`].
-    pub fn protected_mode(&self) -> AccessMode {
+    /// Returns the current [`AccessMode`].
+    pub fn access_mode(&self) -> AccessMode {
         let borrow = self.borrow();
         borrow.mode
     }

--- a/crates/runtime/src/func_env.rs
+++ b/crates/runtime/src/func_env.rs
@@ -217,7 +217,6 @@ impl Inner {
 
     pub fn memory(&self) -> &Memory {
         debug_assert!(self.memory.is_some());
-
         self.memory.as_ref().unwrap()
     }
 

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -20,7 +20,7 @@ pub mod testing;
 pub mod vmcalls;
 
 pub use error::ValidateError;
-pub use func_env::{FuncEnv, AccessMode};
+pub use func_env::{AccessMode, FuncEnv};
 pub use price_registry::PriceResolverRegistry;
-pub use runtime::{compute_account_addr, compute_template_addr, Runtime};
+pub use runtime::{compute_account_addr, compute_template_addr, Runtime, TemplatePriceCache};
 pub use wasm_store::new_store;

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -20,7 +20,7 @@ pub mod testing;
 pub mod vmcalls;
 
 pub use error::ValidateError;
-pub use func_env::{FuncEnv, ProtectedMode};
+pub use func_env::{FuncEnv, AccessMode};
 pub use price_registry::PriceResolverRegistry;
 pub use runtime::{compute_account_addr, compute_template_addr, Runtime};
 pub use wasm_store::new_store;

--- a/crates/runtime/src/price_registry.rs
+++ b/crates/runtime/src/price_registry.rs
@@ -26,8 +26,7 @@ impl PriceResolverRegistry {
         self.price_resolvers.insert(version, price_resolver);
     }
 
-    /// Retrieves the [`PriceResolver`] associated with a certain SVM version
-    /// within `self`.
+    /// Retrieves the [`PriceResolver`] associated with a certain SVM version within `self`.
     pub fn get(&self, version: u16) -> Option<Rc<dyn PriceResolver>> {
         self.price_resolvers.get(&version).cloned()
     }

--- a/crates/runtime/src/runtime/call.rs
+++ b/crates/runtime/src/runtime/call.rs
@@ -1,6 +1,6 @@
 use svm_types::{Address, Context, Envelope, Gas, State, TemplateAddr};
 
-use crate::ProtectedMode;
+use crate::AccessMode;
 
 /// Information regarding a Wasm function call.
 #[doc(hidden)]
@@ -15,5 +15,5 @@ pub struct Call<'a> {
     pub within_spawn: bool,
     pub context: &'a Context,
     pub envelope: &'a Envelope,
-    pub protected_mode: ProtectedMode,
+    pub protected_mode: AccessMode,
 }

--- a/crates/runtime/src/runtime/call.rs
+++ b/crates/runtime/src/runtime/call.rs
@@ -11,7 +11,7 @@ pub struct Call<'a> {
     pub func_name: &'a str,
     pub func_input: &'a [u8],
     pub target: Address,
-    pub template: TemplateAddr,
+    pub template_addr: TemplateAddr,
     pub state: &'a State,
     pub gas_left: GasTank,
     pub within_spawn: bool,

--- a/crates/runtime/src/runtime/call.rs
+++ b/crates/runtime/src/runtime/call.rs
@@ -15,5 +15,5 @@ pub struct Call<'a> {
     pub within_spawn: bool,
     pub context: &'a Context,
     pub envelope: &'a Envelope,
-    pub protected_mode: AccessMode,
+    pub access_mode: AccessMode,
 }

--- a/crates/runtime/src/runtime/call.rs
+++ b/crates/runtime/src/runtime/call.rs
@@ -13,7 +13,7 @@ pub struct Call<'a> {
     pub target: Address,
     pub template: TemplateAddr,
     pub state: &'a State,
-    pub gas_limit: GasTank,
+    pub gas_left: GasTank,
     pub within_spawn: bool,
     pub context: &'a Context,
     pub envelope: &'a Envelope,

--- a/crates/runtime/src/runtime/call.rs
+++ b/crates/runtime/src/runtime/call.rs
@@ -1,6 +1,8 @@
-use svm_types::{Address, Context, Envelope, Gas, State, TemplateAddr};
+use svm_types::{Address, Context, Envelope, State, TemplateAddr};
 
 use crate::AccessMode;
+
+use super::gas_tank::GasTank;
 
 /// Information regarding a Wasm function call.
 #[doc(hidden)]
@@ -11,7 +13,7 @@ pub struct Call<'a> {
     pub target: Address,
     pub template: TemplateAddr,
     pub state: &'a State,
-    pub gas_limit: Gas,
+    pub gas_limit: GasTank,
     pub within_spawn: bool,
     pub context: &'a Context,
     pub envelope: &'a Envelope,

--- a/crates/runtime/src/runtime/gas_tank.rs
+++ b/crates/runtime/src/runtime/gas_tank.rs
@@ -1,0 +1,36 @@
+use svm_types::Gas;
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum GasTank {
+    NonEmpty(u64),
+    Empty,
+}
+
+impl GasTank {
+    pub fn new(gas: Gas) -> Self {
+        let gas = gas.unwrap_or(std::u64::MAX);
+
+        if gas > 0 {
+            GasTank::NonEmpty(gas)
+        } else {
+            GasTank::Empty
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        matches!(self, Self::Empty)
+    }
+
+    pub fn consume(self, gas: u64) -> GasTank {
+        match self {
+            GasTank::Empty => GasTank::Empty,
+            GasTank::NonEmpty(left) => {
+                if left > gas {
+                    GasTank::NonEmpty(left - gas)
+                } else {
+                    GasTank::Empty
+                }
+            }
+        }
+    }
+}

--- a/crates/runtime/src/runtime/gas_tank.rs
+++ b/crates/runtime/src/runtime/gas_tank.rs
@@ -33,4 +33,11 @@ impl GasTank {
             }
         }
     }
+
+    pub fn unwrap(self) -> u64 {
+        match self {
+            GasTank::Empty => 0,
+            GasTank::NonEmpty(gas) => gas,
+        }
+    }
 }

--- a/crates/runtime/src/runtime/mod.rs
+++ b/crates/runtime/src/runtime/mod.rs
@@ -3,9 +3,11 @@
 mod call;
 mod function;
 mod outcome;
+mod price_cache;
 mod runtime;
 
 pub use call::Call;
 pub use function::Function;
 pub use outcome::Outcome;
+pub use price_cache::TemplatePriceCache;
 pub use runtime::{compute_account_addr, compute_template_addr, Runtime};

--- a/crates/runtime/src/runtime/mod.rs
+++ b/crates/runtime/src/runtime/mod.rs
@@ -6,6 +6,8 @@ mod outcome;
 mod price_cache;
 mod runtime;
 
+mod gas_tank;
+
 pub use call::Call;
 pub use function::Function;
 pub use outcome::Outcome;

--- a/crates/runtime/src/runtime/price_cache.rs
+++ b/crates/runtime/src/runtime/price_cache.rs
@@ -29,7 +29,7 @@ impl TemplatePriceCache {
     /// We're using a naive memoization mechanism: we only ever add, never remove.
     /// This means there's no cache invalidation at all.
     /// We can easily afford to do this because the number of [`Template`]s upon Genesis is fixed and won't grow.
-    pub fn template_price(&self, template_addr: &TemplateAddr, program: &Program) -> FuncPrice {
+    pub fn price_of(&self, template_addr: &TemplateAddr, program: &Program) -> FuncPrice {
         let mut cache = self.cache.borrow_mut();
 
         if let Some(prices) = cache.get(&template_addr) {

--- a/crates/runtime/src/runtime/price_cache.rs
+++ b/crates/runtime/src/runtime/price_cache.rs
@@ -1,0 +1,32 @@
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+
+use svm_gas::FuncPrice;
+use svm_types::TemplateAddr;
+
+use crate::PriceResolverRegistry;
+
+/// A naive cache for [`Template`](svm_types::Template)s' [`FuncPrice`]s.
+///
+/// In the future, the cache key will also include an identifier for which
+/// [`PriceResolver`](svm_gas::PriceResolver) should be used (possibly an `u16`?).
+pub struct TemplatePriceCache {
+    registry: PriceResolverRegistry,
+    cache: Rc<RefCell<HashMap<TemplateAddr, FuncPrice>>>,
+}
+
+impl TemplatePriceCache {
+    pub fn new(registry: PriceResolverRegistry) -> Self {
+        Self {
+            registry,
+            cache: Rc::new(RefCell::new(HashMap::new())),
+        }
+    }
+}
+
+// let template_prices = template_prices.unwrap_or_default();
+//
+// `template_prices` offers an easy way to inject an append-only, naive caching mechanism to
+// the [`Template`] pricing logic; using a `None` will result in a new
+// empty cache and on-the-fly calculation for all [`Template`]s.

--- a/crates/runtime/src/runtime/price_cache.rs
+++ b/crates/runtime/src/runtime/price_cache.rs
@@ -40,10 +40,7 @@ impl TemplatePriceCache {
             let pp = ProgramPricing::new(resolver);
             let prices = pp.visit(&program).unwrap();
 
-            {
-                cache.insert(template_addr.clone(), prices);
-            }
-
+            cache.insert(template_addr.clone(), prices);
             cache.get(template_addr).unwrap().clone()
         }
     }

--- a/crates/runtime/src/runtime/price_cache.rs
+++ b/crates/runtime/src/runtime/price_cache.rs
@@ -28,7 +28,7 @@ impl TemplatePriceCache {
 
     /// We're using a naive memoization mechanism: we only ever add, never remove.
     /// This means there's no cache invalidation at all.
-    /// We can easily afford to do this because the number of [`Template`]s upon Genesis is fixed and won't grow.
+    /// We can easily afford to do this because the number of [`Template`](svm_types::Template)s upon Genesis is fixed and won't grow.
     pub fn price_of(&self, template_addr: &TemplateAddr, program: &Program) -> FuncPrice {
         let mut cache = self.cache.borrow_mut();
 

--- a/crates/runtime/src/runtime/runtime.rs
+++ b/crates/runtime/src/runtime/runtime.rs
@@ -55,7 +55,7 @@ impl Runtime {
             template,
             target: target.clone(),
             within_spawn: true,
-            gas_limit: gas_left,
+            gas_left,
             access_mode: AccessMode::FullAccess,
             envelope,
             context,
@@ -115,7 +115,7 @@ impl Runtime {
     {
         self.validate_func_usage(call, template, func_env)?;
 
-        let module = self.compile_template(store, func_env, &template, call.gas_limit)?;
+        let module = self.compile_template(store, func_env, &template, call.gas_left)?;
         let instance = self.instantiate(func_env, &module, import_object)?;
 
         set_memory(func_env, &instance);
@@ -446,7 +446,7 @@ impl Runtime {
             target: target.clone(),
             template,
             state: context.state(),
-            gas_limit: gas_left,
+            gas_left,
             access_mode,
             within_spawn: false,
             envelope,
@@ -529,10 +529,10 @@ impl Runtime {
         let sections = Sections::decode_bytes(message).expect(ERR_VALIDATE_DEPLOY);
         let template = Template::from_sections(sections);
 
-        let gas_limit = envelope.gas_limit();
+        let gas_left = envelope.gas_limit();
         let install_price = svm_gas::transaction::deploy(message);
 
-        if gas_limit < install_price {
+        if gas_left < install_price {
             return DeployReceipt::new_oog();
         }
 

--- a/crates/runtime/src/runtime/runtime.rs
+++ b/crates/runtime/src/runtime/runtime.rs
@@ -317,11 +317,6 @@ impl Runtime {
     ) -> std::result::Result<Template, RuntimeFailure> {
         let template_storage = TemplateStorage::load(self.gs.clone(), &template_addr).unwrap();
         let sections = template_storage.sections().unwrap();
-
-        for kind in sections.kinds() {
-            dbg!(kind);
-        }
-
         let template = Template::from_sections(sections);
 
         // TODO:

--- a/crates/runtime/src/runtime/runtime.rs
+++ b/crates/runtime/src/runtime/runtime.rs
@@ -475,6 +475,7 @@ impl Runtime {
     pub fn create_account(
         &mut self,
         account_addr: &Address,
+        template_addr: &TemplateAddr,
         name: String,
         balance: u64,
         counter: u128,
@@ -483,7 +484,7 @@ impl Runtime {
             self.gs.clone(),
             account_addr,
             name,
-            TemplateAddr::god_template(),
+            template_addr.clone(),
             balance,
             counter,
         )
@@ -584,7 +585,7 @@ impl Runtime {
 
         let account = spawn.account();
         let target = compute_account_addr(&spawn);
-        self.create_account(&target, account.name().to_string(), 0, 0);
+        self.create_account(&target, &template_addr, account.name().to_string(), 0, 0);
         self.call_ctor(&spawn, target, envelope, context, gas_left)
     }
 

--- a/crates/runtime/src/runtime/runtime.rs
+++ b/crates/runtime/src/runtime/runtime.rs
@@ -475,11 +475,31 @@ impl Runtime {
         Ok(())
     }
 
-    /// Creates a new account at genesis with the given information.
+    /// Creates a new `Genesis Account`.
+    pub fn create_genesis_account(
+        &mut self,
+        account_addr: &Address,
+        name: String,
+        balance: u64,
+        counter: u128,
+    ) -> Result<()> {
+        self.create_account(
+            account_addr,
+            TemplateAddr::god_template(),
+            name,
+            balance,
+            counter,
+        )
+        .unwrap();
+
+        Ok(())
+    }
+
+    /// Creates a new `Account` with the given params.
     pub fn create_account(
         &mut self,
         account_addr: &Address,
-        template_addr: &TemplateAddr,
+        template_addr: TemplateAddr,
         name: String,
         balance: u64,
         counter: u128,
@@ -488,7 +508,7 @@ impl Runtime {
             self.gs.clone(),
             account_addr,
             name,
-            template_addr.clone(),
+            template_addr,
             balance,
             counter,
         )
@@ -597,8 +617,14 @@ impl Runtime {
         let account = spawn.account();
         let target = compute_account_addr(&spawn);
 
-        self.create_account(&target, &template_addr, account.name().to_string(), 0, 0)
-            .unwrap();
+        self.create_account(
+            &target,
+            template_addr.clone(),
+            account.name().to_string(),
+            0,
+            0,
+        )
+        .unwrap();
 
         self.call_ctor(&spawn, target, envelope, context, gas_left)
     }

--- a/crates/runtime/src/runtime/runtime.rs
+++ b/crates/runtime/src/runtime/runtime.rs
@@ -479,7 +479,7 @@ impl Runtime {
         name: String,
         balance: u64,
         counter: u128,
-    ) {
+    ) -> Result<()> {
         AccountStorage::create(
             self.gs.clone(),
             account_addr,
@@ -489,6 +489,8 @@ impl Runtime {
             counter,
         )
         .unwrap();
+
+        Ok(())
     }
 
     /// Validates syntactically a binary `Deploy Template` message prior to executing it.
@@ -585,7 +587,10 @@ impl Runtime {
 
         let account = spawn.account();
         let target = compute_account_addr(&spawn);
-        self.create_account(&target, &template_addr, account.name().to_string(), 0, 0);
+
+        self.create_account(&target, &template_addr, account.name().to_string(), 0, 0)
+            .unwrap();
+
         self.call_ctor(&spawn, target, envelope, context, gas_left)
     }
 

--- a/crates/runtime/src/runtime/runtime.rs
+++ b/crates/runtime/src/runtime/runtime.rs
@@ -442,7 +442,7 @@ impl Runtime {
         name: String,
         balance: u64,
         counter: u128,
-    ) -> Result<()> {
+    ) {
         AccountStorage::create(
             self.gs.clone(),
             account_addr,
@@ -452,8 +452,6 @@ impl Runtime {
             counter,
         )
         .unwrap();
-
-        Ok(())
     }
 
     /// Validates syntactically a binary `Deploy Template` message prior to executing it.
@@ -564,17 +562,7 @@ impl Runtime {
             Ok(gas_left) => {
                 let account = spawn.account();
                 let target = compute_account_addr(&spawn);
-
-                AccountStorage::create(
-                    self.gs.clone(),
-                    &target,
-                    account.name().to_string(),
-                    account.template_addr().clone(),
-                    0,
-                    0,
-                )
-                .unwrap();
-
+                self.create_account(&target, account.name().to_string(), 0, 0);
                 self.call_ctor(&spawn, target, gas_left, envelope, context)
             }
             Err(..) => SpawnReceipt::new_oog(Vec::new()),

--- a/crates/runtime/src/testing.rs
+++ b/crates/runtime/src/testing.rs
@@ -8,7 +8,6 @@ use svm_types::{
     TemplateAddr, Transaction,
 };
 
-use crate::price_registry::PriceResolverRegistry;
 use crate::Runtime;
 
 /// Hold a Wasm file in textual or binary form

--- a/crates/runtime/src/testing.rs
+++ b/crates/runtime/src/testing.rs
@@ -44,26 +44,12 @@ impl<'a> From<&'a [u8]> for WasmFile<'a> {
 
 /// Creates an in-memory `Runtime` backed by a `state_kv`.
 pub fn create_memory_runtime() -> Runtime {
-    let imports = ("sm".to_string(), wasmer::Exports::new());
-
-    Runtime::new(
-        imports,
-        GlobalState::in_memory(),
-        PriceResolverRegistry::default(),
-        None,
-    )
+    Runtime::new(GlobalState::in_memory())
 }
 
 /// Creates an in-memory `Runtime` backed by a `state_kv`.
 pub fn create_db_runtime(path: &str) -> Runtime {
-    let imports = ("sm".to_string(), wasmer::Exports::new());
-
-    Runtime::new(
-        imports,
-        GlobalState::new(path),
-        PriceResolverRegistry::default(),
-        None,
-    )
+    Runtime::new(GlobalState::new(path))
 }
 
 /// Builds a binary `Deploy Template` transaction.
@@ -87,7 +73,6 @@ pub fn build_deploy(
 /// Builds a binary `Spawn Account` transaction.
 pub fn build_spawn(template: &TemplateAddr, name: &str, ctor: &str, calldata: &[u8]) -> Vec<u8> {
     let spawn = SpawnAccount::new(0, template, name, ctor, calldata);
-
     spawn.encode_to_vec()
 }
 

--- a/crates/runtime/src/testing.rs
+++ b/crates/runtime/src/testing.rs
@@ -8,7 +8,7 @@ use svm_types::{
     TemplateAddr, Transaction,
 };
 
-use crate::Runtime;
+use crate::{PriceResolverRegistry, Runtime, TemplatePriceCache};
 
 /// Hold a Wasm file in textual or binary form
 pub enum WasmFile<'a> {
@@ -41,14 +41,16 @@ impl<'a> From<&'a [u8]> for WasmFile<'a> {
     }
 }
 
-/// Creates an in-memory `Runtime` backed by a `state_kv`.
+/// Creates an [`Runtime`] backed by an in-memory [`GlobalState`].
 pub fn create_memory_runtime() -> Runtime {
-    Runtime::new(GlobalState::in_memory())
+    let registry = PriceResolverRegistry::default();
+    Runtime::new(GlobalState::in_memory(), TemplatePriceCache::new(registry))
 }
 
-/// Creates an in-memory `Runtime` backed by a `state_kv`.
+/// Creates an [`Runtime`] backed by the [`GlobalState`].
 pub fn create_db_runtime(path: &str) -> Runtime {
-    Runtime::new(GlobalState::new(path))
+    let registry = PriceResolverRegistry::default();
+    Runtime::new(GlobalState::new(path), TemplatePriceCache::new(registry))
 }
 
 /// Builds a binary `Deploy Template` transaction.

--- a/crates/runtime/src/vmcalls/mod.rs
+++ b/crates/runtime/src/vmcalls/mod.rs
@@ -46,7 +46,6 @@ pub fn wasmer_register(store: &Store, env: &FuncEnv, ns: &mut Exports) {
     ns.insert("svm_store160", func!(store, env, store160));
 
     ns.insert("svm_log", func!(store, env, log));
-
     ns.insert("svm_transfer", func!(store, env, svm_transfer));
 }
 

--- a/crates/runtime/tests/runtime_tests.rs
+++ b/crates/runtime/tests/runtime_tests.rs
@@ -225,10 +225,10 @@ fn memory_runtime_spawn_invoking_non_ctor_fails() {
     let message = testing::build_spawn(&template_addr, name, ctor, &calldata);
     let receipt = runtime.spawn(&envelope, &message, &context);
 
-    assert!(matches!(
-        receipt.error.unwrap(),
-        RuntimeError::FuncNotCtor { .. }
-    ));
+    // assert!(matches!(
+    //     receipt.error.unwrap(),
+    //     RuntimeError::FuncNotCtor { .. }
+    // ));
 }
 
 #[test]

--- a/crates/runtime/tests/runtime_tests.rs
+++ b/crates/runtime/tests/runtime_tests.rs
@@ -227,7 +227,7 @@ fn memory_runtime_spawn_invoking_non_ctor_fails() {
 
     assert!(matches!(
         receipt.error.unwrap(),
-        RuntimeError::FuncNotAllowed { .. }
+        RuntimeError::FuncNotCtor { .. }
     ));
 }
 

--- a/crates/runtime/tests/runtime_tests.rs
+++ b/crates/runtime/tests/runtime_tests.rs
@@ -225,10 +225,10 @@ fn memory_runtime_spawn_invoking_non_ctor_fails() {
     let message = testing::build_spawn(&template_addr, name, ctor, &calldata);
     let receipt = runtime.spawn(&envelope, &message, &context);
 
-    // assert!(matches!(
-    //     receipt.error.unwrap(),
-    //     RuntimeError::FuncNotCtor { .. }
-    // ));
+    assert!(matches!(
+        receipt.error.unwrap(),
+        RuntimeError::FuncNotCtor { .. }
+    ));
 }
 
 #[test]

--- a/crates/runtime/tests/vmcalls_tests.rs
+++ b/crates/runtime/tests/vmcalls_tests.rs
@@ -4,7 +4,7 @@ use wasmer::{imports, FromToNativeWasmType, NativeFunc};
 
 use svm_layout::FixedLayout;
 use svm_runtime::testing::WasmFile;
-use svm_runtime::{vmcalls, FuncEnv, AccessMode};
+use svm_runtime::{vmcalls, AccessMode, FuncEnv};
 use svm_state::{AccountStorage, GlobalState};
 use svm_types::{Address, BytesPrimitive, Context, Envelope, ReceiptLog, TemplateAddr};
 

--- a/crates/runtime/tests/vmcalls_tests.rs
+++ b/crates/runtime/tests/vmcalls_tests.rs
@@ -4,7 +4,7 @@ use wasmer::{imports, FromToNativeWasmType, NativeFunc};
 
 use svm_layout::FixedLayout;
 use svm_runtime::testing::WasmFile;
-use svm_runtime::{vmcalls, FuncEnv, ProtectedMode};
+use svm_runtime::{vmcalls, FuncEnv, AccessMode};
 use svm_state::{AccountStorage, GlobalState};
 use svm_types::{Address, BytesPrimitive, Context, Envelope, ReceiptLog, TemplateAddr};
 
@@ -134,7 +134,7 @@ fn vmcalls_get32_set32() {
         &context,
         template_addr,
         target_addr,
-        ProtectedMode::FullAccess,
+        AccessMode::FullAccess,
     );
 
     let import_object = imports! {
@@ -180,7 +180,7 @@ fn vmcalls_get64_set64() {
         &context,
         template_addr,
         target_addr,
-        ProtectedMode::FullAccess,
+        AccessMode::FullAccess,
     );
 
     let import_object = imports! {
@@ -228,7 +228,7 @@ fn vmcalls_load160() {
         &context,
         template_addr,
         target_addr.clone(),
-        ProtectedMode::FullAccess,
+        AccessMode::FullAccess,
     );
 
     let import_object = imports! {
@@ -282,7 +282,7 @@ fn vmcalls_store160() {
         &context,
         template_addr,
         target_addr.clone(),
-        ProtectedMode::FullAccess,
+        AccessMode::FullAccess,
     );
 
     let import_object = imports! {
@@ -331,7 +331,7 @@ fn vmcalls_log() {
         &context,
         template_addr,
         target_addr,
-        ProtectedMode::AccessDenied,
+        AccessMode::AccessDenied,
     );
 
     let import_object = imports! {
@@ -390,7 +390,7 @@ fn setup_svm_transfer_test() -> (
         &context,
         template,
         src_addr.clone(),
-        ProtectedMode::FullAccess,
+        AccessMode::FullAccess,
     );
 
     let import_object = imports! {

--- a/crates/state/src/account_storage.rs
+++ b/crates/state/src/account_storage.rs
@@ -19,7 +19,11 @@ pub struct AccountStorage {
 
     /// The owner's [`Address`] of this [`AccountStorage`].
     pub address: Address,
+
+    /// The [`TemplateAddr`] associated with `Account`.
     template_addr: TemplateAddr,
+
+    /// The `Account`'s layout.
     layout: FixedLayout,
 }
 

--- a/crates/types/src/error.rs
+++ b/crates/types/src/error.rs
@@ -29,6 +29,10 @@ pub enum RuntimeError {
         func: String,
         msg: String,
     },
+    FuncNotCtor {
+        template: TemplateAddr,
+        func: String,
+    },
     FuncNotAllowed {
         target: Address,
         template: TemplateAddr,

--- a/crates/types/src/template/mod.rs
+++ b/crates/types/src/template/mod.rs
@@ -105,7 +105,6 @@ impl Template {
     /// Panics if there is no `Header Section`
     pub fn header_section(&self) -> &HeaderSection {
         let section = self.get(SectionKind::Header);
-
         section.as_header()
     }
 
@@ -116,7 +115,6 @@ impl Template {
     /// Panics if there is no `Code Section`
     pub fn code_section(&self) -> &CodeSection {
         let section = self.get(SectionKind::Code);
-
         section.as_code()
     }
 
@@ -127,7 +125,6 @@ impl Template {
     /// Panics if there is no `Code Section`
     pub fn code(&self) -> &[u8] {
         let section = self.code_section();
-
         section.code()
     }
 
@@ -138,7 +135,6 @@ impl Template {
     /// Panics if there is no `Data Section`
     pub fn data_section(&self) -> &DataSection {
         let section = self.get(SectionKind::Data);
-
         section.as_data()
     }
 
@@ -149,7 +145,6 @@ impl Template {
         let layouts = data.layouts();
 
         let layout = layouts.first().unwrap();
-
         layout.as_fixed()
     }
 
@@ -160,7 +155,6 @@ impl Template {
     /// Panics if there is no `Ctors Section`
     pub fn ctors_section(&self) -> &CtorsSection {
         let section = self.get(SectionKind::Ctors);
-
         section.as_ctors()
     }
 
@@ -171,7 +165,6 @@ impl Template {
     /// Panics if there is no `Ctors Section`
     pub fn ctors(&self) -> &[String] {
         let section = self.ctors_section();
-
         section.ctors()
     }
 
@@ -182,11 +175,7 @@ impl Template {
     /// Panics if there is no `Ctors Section`
     pub fn is_ctor(&self, func_name: &str) -> bool {
         let ctors = self.ctors();
-
-        ctors
-            .iter()
-            .find(|ctor| ctor.as_str() == func_name)
-            .is_some()
+        ctors.iter().any(|ctor| ctor.as_str() == func_name)
     }
 
     /// Borrows the `Schema Section`
@@ -196,7 +185,6 @@ impl Template {
     /// Panics if there is no `Schema Section`
     pub fn schema_section(&self) -> &SchemaSection {
         let section = self.get(SectionKind::Schema);
-
         section.as_schema()
     }
 
@@ -214,7 +202,6 @@ impl Template {
     /// Panics if there is no `Deploy Section`
     pub fn deploy_section(&self) -> &DeploySection {
         let section = self.get(SectionKind::Deploy);
-
         section.as_deploy()
     }
 
@@ -225,7 +212,6 @@ impl Template {
     /// Panics if there is no `Deploy Section`
     pub fn template_addr(&self) -> &TemplateAddr {
         let section = self.deploy_section();
-
         section.template()
     }
 
@@ -243,5 +229,10 @@ impl Template {
     /// Returns `None` when there is no `Section` of the specified `SectionKind`
     pub fn try_get(&self, kind: SectionKind) -> Option<&Section> {
         self.sections.try_get(kind)
+    }
+
+    /// Returns whether Section exists
+    pub fn contains(&self, kind: SectionKind) -> bool {
+        self.sections.try_get(kind).is_some()
     }
 }

--- a/crates/types/src/template/section.rs
+++ b/crates/types/src/template/section.rs
@@ -262,6 +262,11 @@ impl Sections {
         self.inner.contains_key(&kind)
     }
 
+    /// Returns the [`Section`]s kinds held.
+    pub fn kinds(&self) -> indexmap::map::Keys<SectionKind, Section> {
+        self.inner.keys()
+    }
+
     /// Returns the [`Section`] of the requested `kind`.
     ///
     /// # Panics


### PR DESCRIPTION
I want to refactor the `Runtime` of SVM.

Here are the changes done on this one:

#### Adding `RuntimeError::FuncNotCtor`

The `FuncNotAllowed` requires a `target`.
Since we don't really have a `target` when spawning, I've ended up the `FuncNotCtor`


#### Removal of `Imports` dependency

Initially, the `Runtime` expected external imports.
Back then, we thought that `Global-State`-related host functions would be implemented within the `go-spacemesh`.
Since then, the `Global State` has been moved to the Rust land, so we ended up with having setting empty `imports` as a parameter when initializing the `Runtime`


#### Moved `Template Pricing` to another file

I created `TemplatePriceCache` to act as the cache for the `Template Pricing`. 
The `Runtime` expects now that cache as a dependency upon initialization. 
In practice, it'd be ideal to have only a single cache used throughout the process lifetime.


### Added `GasTank`

I thought it would make the code more readable if the repeating pattern of checking whether we've enough gas during will be less explicit and noisy in the code.

I've also added two helpers: `check_gas_for_payload` and `check_gas_for_func`.
Both expect a paramere named `gas_left` and its type of `GasTank`.
Each helper checks first whether there is any `gas in the tank` and returns immediately if the tank is empty.

The `GasTank` could have been an `Option<u64>,` but I think it's nicer as it's now.


#### Other

* Renamed `ProtectedMode` to `AccessMode` (also added `ImmutableOnly` option for the future).
* Removed in the `exec` function the creation of `AccountStorage` for the `target` - it seems unnecessary. If the target doesn't exist, we should fail (to be done in a separate PR)
* Added more `TODO` under `src/runtime/runtime.rs`
* Might be better to review `src/runtime/runtime.rs` in the editor.