### PR TITLE
Separate macOS asset files by arch

### DIFF
--- a/.github/copy-artifacts.sh
+++ b/.github/copy-artifacts.sh
@@ -19,7 +19,8 @@ elif [[ "${OS}" == "macos-latest" ]]; then
     cp target/release/libsvm_runtime_ffi.dylib bins/x86_64/libsvm.dylib
     cp target/release/libsvm_runtime_ffi.a bins/x86_64/libsvm.a
     cp target/release/svm-cli bins/x86_64/svm-cli
-    cp target/release/svm.h bins/svm.h
+    cp target/release/svm.h bins/x86_64/svm.h
+    cp target/release/svm.h bins/aarch64/svm.h
 elif [[ "${OS}" == "ubuntu-latest" ]]; then
     cp target/release/libsvm_runtime_ffi.so bins/libsvm.so
     cp target/release/libsvm_runtime_ffi.a bins/libsvm.a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,13 +28,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         profile: [release]
-        include:
-          - os: ubuntu-latest
-            cargo-targets: ["x86_64-unknown-linux-gnu"]
-          - os: macos-latest
-            cargo-target: ["aarch64-apple-darwin", "x86_64-apple-darwin"]
-          - os: windows-latest
-            cargo-target: ["x86_64-pc-windows-msvc"]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
@@ -59,7 +52,13 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --target ${{ matrix.cargo-target }} --release -p svm-runtime-ffi -p svm-cli --no-default-features
+          args: --release -p svm-runtime-ffi -p svm-cli --no-default-features
+      - name: Cargo Build (Apple Silicon)
+        if: matrix.os == 'macos-latest'
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --target aarch64-apple-darwin --release -p svm-runtime-ffi -p svm-cli --no-default-features
       - name: Prepare Artifacts
         run: |
           ls target

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,9 +231,9 @@ jobs:
           cd ../bins-Windows-release
           zip -r ../svm-windows-v${{ env.VERSION }}.zip *
           cd ../bins-macOS-release/x86_64
-          zip -r ../svm-macos-v${{ env.VERSION }}.zip *
+          zip -r ../../svm-macos-v${{ env.VERSION }}.zip *
           cd ../aarch64
-          zip -r ../svm-macos-m1-v${{ env.VERSION }}.zip *
+          zip -r ../../svm-macos-m1-v${{ env.VERSION }}.zip *
           cd ../..
           cp svm_codec.wasm/svm_codec.wasm svm_codec_v${{ env.VERSION }}.wasm
       - uses: softprops/action-gh-release@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,11 +30,11 @@ jobs:
         profile: [release]
         include:
           - os: ubuntu-latest
-            target-args:
+            cargo-targets: ["x86_64-unknown-linux-gnu"]
           - os: macos-latest
-            target-args: --target aarch64-apple-darwin --target x86_64-apple-darwin
+            cargo-target: ["aarch64-apple-darwin", "x86_64-apple-darwin"]
           - os: windows-latest
-            target-args:
+            cargo-target: ["x86_64-pc-windows-msvc"]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
@@ -59,7 +59,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: ${{ matrix.target-args }} --release -p svm-runtime-ffi -p svm-cli --no-default-features
+          args: --target ${{ matrix.cargo-target }} --release -p svm-runtime-ffi -p svm-cli --no-default-features
       - name: Prepare Artifacts
         run: |
           ls target

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,11 @@ jobs:
         profile: [release]
         include:
           - os: ubuntu-latest
+            target-args:
           - os: macos-latest
+            target-args: --target aarch64-apple-darwin --target x86_64-apple-darwin
           - os: windows-latest
+            target-args:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
@@ -56,18 +59,12 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --${{ matrix.profile }} -p svm-runtime-ffi -p svm-cli --no-default-features
-      - uses: actions-rs/cargo@v1
-        if: matrix.os == 'macos-latest'
-        with:
-          command: build
-          args: --target aarch64-apple-darwin --${{ matrix.profile }} -p svm-runtime-ffi -p svm-cli --no-default-features
-      - name: List Cargo artifacts
+          args: ${{ matrix.target-args }} --release -p svm-runtime-ffi -p svm-cli --no-default-features
+      - name: Prepare Artifacts
         run: |
           ls target
-          ls target/${{ matrix.profile }}
-      - name: Prepare Artifacts
-        run: ./.github/copy-artifacts.sh
+          ls target/release
+          ./.github/copy-artifacts.sh
         env:
           OS: ${{ matrix.os }}
       - uses: msys2/setup-msys2@v2
@@ -234,9 +231,11 @@ jobs:
           zip -r ../svm-linux-v${{ env.VERSION }}.zip *
           cd ../bins-Windows-release
           zip -r ../svm-windows-v${{ env.VERSION }}.zip *
-          cd ../bins-macOS-release
+          cd ../bins-macOS-release/x86_64
           zip -r ../svm-macos-v${{ env.VERSION }}.zip *
-          cd ..
+          cd ../aarch64
+          zip -r ../svm-macos-m1-v${{ env.VERSION }}.zip *
+          cd ../..
           cp svm_codec.wasm/svm_codec.wasm svm_codec_v${{ env.VERSION }}.wasm
       - uses: softprops/action-gh-release@v1
         with:
@@ -245,6 +244,7 @@ jobs:
             svm-linux-v${{ env.VERSION }}.zip
             svm-windows-v${{ env.VERSION }}.zip
             svm-macos-v${{ env.VERSION }}.zip
+            svm-macos-m1-v${{ env.VERSION }}.zip
             svm_codec_v${{ env.VERSION }}.wasm
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Separates `x86_64` and `aarch64` release asset files for macOS.